### PR TITLE
Phase 1: Core SDK — EVM cross-chain swaps to Gnosis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+*.tsbuildinfo
+.DS_Store

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,5 @@
+src/
+*.config.ts
+tsconfig.json
+vitest.config.ts
+.gitignore

--- a/package.json
+++ b/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "@upcoming/multichain-sdk",
+  "version": "0.1.0",
+  "description": "Headless SDK for cross-chain token swaps to Gnosis chain and Swarm postage batch creation",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "scripts": {
+    "build": "tsup",
+    "check": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@relayprotocol/relay-sdk": "^3.0.0",
+    "@upcoming/multichain-library": "^0.10.0",
+    "cafe-utility": "^33.8.0",
+    "tslib": "^2.8.1",
+    "viem": "^2.38.1"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.9.0",
+    "vitest": "^3.0.0"
+  },
+  "peerDependencies": {
+    "@solana/web3.js": "^2.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@solana/web3.js": {
+      "optional": true
+    }
+  },
+  "license": "MIT"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,2246 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@relayprotocol/relay-sdk':
+        specifier: ^3.0.0
+        version: 3.2.0(viem@2.47.5(typescript@5.9.3))
+      '@solana/web3.js':
+        specifier: ^2.0.0
+        version: 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3)
+      '@upcoming/multichain-library':
+        specifier: ^0.10.0
+        version: 0.10.0(typescript@5.9.3)
+      cafe-utility:
+        specifier: ^33.8.0
+        version: 33.8.0
+      tslib:
+        specifier: ^2.8.1
+        version: 2.8.1
+      viem:
+        specifier: ^2.38.1
+        version: 2.47.5(typescript@5.9.3)
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.15
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(postcss@8.5.8)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.9.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/node@22.19.15)
+
+packages:
+
+  '@adraffy/ens-normalize@1.11.1':
+    resolution: {integrity: sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==}
+
+  '@esbuild/aix-ppc64@0.27.4':
+    resolution: {integrity: sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.4':
+    resolution: {integrity: sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.4':
+    resolution: {integrity: sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.4':
+    resolution: {integrity: sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.4':
+    resolution: {integrity: sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.4':
+    resolution: {integrity: sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.4':
+    resolution: {integrity: sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.4':
+    resolution: {integrity: sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.4':
+    resolution: {integrity: sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.4':
+    resolution: {integrity: sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.4':
+    resolution: {integrity: sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.4':
+    resolution: {integrity: sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.4':
+    resolution: {integrity: sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.4':
+    resolution: {integrity: sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.4':
+    resolution: {integrity: sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.4':
+    resolution: {integrity: sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.4':
+    resolution: {integrity: sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.4':
+    resolution: {integrity: sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.4':
+    resolution: {integrity: sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.4':
+    resolution: {integrity: sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.4':
+    resolution: {integrity: sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.4':
+    resolution: {integrity: sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.4':
+    resolution: {integrity: sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.4':
+    resolution: {integrity: sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.4':
+    resolution: {integrity: sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.4':
+    resolution: {integrity: sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@noble/ciphers@1.3.0':
+    resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/curves@1.9.1':
+    resolution: {integrity: sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@relayprotocol/relay-sdk@3.2.0':
+    resolution: {integrity: sha512-d18NamgWRKBSby470XcfsPaXIIMkehPrVUa+/7VWlusG98QtkKLk/FZeZMGeitbCuAeTMeVVykCpbF46p8i9vA==}
+    peerDependencies:
+      viem: '>=2.26.0'
+
+  '@rollup/rollup-android-arm-eabi@4.59.0':
+    resolution: {integrity: sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.59.0':
+    resolution: {integrity: sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.59.0':
+    resolution: {integrity: sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.59.0':
+    resolution: {integrity: sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.59.0':
+    resolution: {integrity: sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.59.0':
+    resolution: {integrity: sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.59.0':
+    resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.59.0':
+    resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.59.0':
+    resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.59.0':
+    resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.59.0':
+    resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.59.0':
+    resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.59.0':
+    resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.59.0':
+    resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.59.0':
+    resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.59.0':
+    resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.59.0':
+    resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.59.0':
+    resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.59.0':
+    resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.59.0':
+    resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.59.0':
+    resolution: {integrity: sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.59.0':
+    resolution: {integrity: sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.59.0':
+    resolution: {integrity: sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.59.0':
+    resolution: {integrity: sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.59.0':
+    resolution: {integrity: sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@scure/base@1.2.6':
+    resolution: {integrity: sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==}
+
+  '@scure/bip32@1.7.0':
+    resolution: {integrity: sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==}
+
+  '@scure/bip39@1.6.0':
+    resolution: {integrity: sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==}
+
+  '@solana/accounts@2.0.0':
+    resolution: {integrity: sha512-1CE4P3QSDH5x+ZtSthMY2mn/ekROBnlT3/4f3CHDJicDvLQsgAq2yCvGHsYkK3ZA0mxhFLuhJVjuKASPnmG1rQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/addresses@2.0.0':
+    resolution: {integrity: sha512-8n3c/mUlH1/z+pM8e7OJ6uDSXw26Be0dgYiokiqblO66DGQ0d+7pqFUFZ5pEGjJ9PU2lDTSfY8rHf4cemOqwzQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/assertions@2.0.0':
+    resolution: {integrity: sha512-NyPPqZRNGXs/GAjfgsw7YS6vCTXWt4ibXveS+ciy5sdmp/0v3pA6DlzYjleF9Sljrew0IiON15rjaXamhDxYfQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/codecs-core@2.0.0':
+    resolution: {integrity: sha512-qCG+3hDU5Pm8V6joJjR4j4Zv9md1z0RaecniNDIkEglnxmOUODnmPLWbtOjnDylfItyuZeDihK8hkewdj8cUtw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/codecs-data-structures@2.0.0':
+    resolution: {integrity: sha512-N98Y4jsrC/XeOgqrfsGqcOFIaOoMsKdAxOmy5oqVaEN67YoGSLNC9ROnqamOAOrsZdicTWx9/YLKFmQi9DPh1A==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/codecs-numbers@2.0.0':
+    resolution: {integrity: sha512-r66i7VzJO1MZkQWZIAI6jjJOFVpnq0+FIabo2Z2ZDtrArFus/SbSEv543yCLeD2tdR/G/p+1+P5On10qF50Y1Q==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/codecs-strings@2.0.0':
+    resolution: {integrity: sha512-dNqeCypsvaHcjW86H0gYgAZGGkKVBeKVeh7WXlOZ9kno7PeQ2wNkpccyzDfuzaIsKv+HZUD3v/eo86GCvnKazQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      fastestsmallesttextencoderdecoder: ^1.0.22
+      typescript: '>=5'
+
+  '@solana/codecs@2.0.0':
+    resolution: {integrity: sha512-xneIG5ppE6WIGaZCK7JTys0uLhzlnEJUdBO8nRVIyerwH6aqCfb0fGe7q5WNNYAVDRSxC0Pc1TDe1hpdx3KWmQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/errors@2.0.0':
+    resolution: {integrity: sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==}
+    engines: {node: '>=20.18.0'}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/fast-stable-stringify@2.0.0':
+    resolution: {integrity: sha512-EsIx9z+eoxOmC+FpzhEb+H67CCYTbs/omAqXD4EdEYnCHWrI1li1oYBV+NoKzfx8fKlX+nzNB7S/9kc4u7Etpw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/functional@2.0.0':
+    resolution: {integrity: sha512-Sj+sLiUTimnMEyGnSLGt0lbih2xPDUhxhonnrIkPwA+hjQ3ULGHAxeevHU06nqiVEgENQYUJ5rCtHs4xhUFAkQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/instructions@2.0.0':
+    resolution: {integrity: sha512-MiTEiNF7Pzp+Y+x4yadl2VUcNHboaW5WP52psBuhHns3GpbbruRv5efMpM9OEQNe1OsN+Eg39vjEidX55+P+DQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/keys@2.0.0':
+    resolution: {integrity: sha512-SSLSX8BXRvfLKBqsmBghmlhMKpwHeWd5CHi5zXgTS1BRrtiU6lcrTVC9ie6B+WaNNq7oe3e6K5bdbhu3fFZ+0g==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/options@2.0.0':
+    resolution: {integrity: sha512-OVc4KnYosB8oAukQ/htgrxXSxlUP6gUu5Aau6d/BgEkPQzWd/Pr+w91VWw3i3zZuu2SGpedbyh05RoJBe/hSXA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/programs@2.0.0':
+    resolution: {integrity: sha512-JPIKB61pWfODnsvEAaPALc6vR5rn7kmHLpFaviWhBtfUlEVgB8yVTR0MURe4+z+fJCPRV5wWss+svA4EeGDYzQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/promises@2.0.0':
+    resolution: {integrity: sha512-4teQ52HDjK16ORrZe1zl+Q9WcZdQ+YEl0M1gk59XG7D0P9WqaVEQzeXGnKSCs+Y9bnB1u5xCJccwpUhHYWq6gg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/rpc-api@2.0.0':
+    resolution: {integrity: sha512-1FwitYxwADMF/6zKP2kNXg8ESxB6GhNBNW1c4f5dEmuXuBbeD/enLV3WMrpg8zJkIaaYarEFNbt7R7HyFzmURQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/rpc-parsed-types@2.0.0':
+    resolution: {integrity: sha512-VCeY/oKVEtBnp8EDOc5LSSiOeIOLFIgLndcxqU0ij/cZaQ01DOoHbhluvhZtU80Z3dUeicec8TiMgkFzed+WhQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/rpc-spec-types@2.0.0':
+    resolution: {integrity: sha512-G2lmhFhgtxMQd/D6B04BHGE7bm5dMZdIPQNOqVGhzNAVjrmyapD3JN2hKAbmaYPe97wLfZERw0Ux1u4Y6q7TqA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/rpc-spec@2.0.0':
+    resolution: {integrity: sha512-1uIDzj7vocCUqfOifjv1zAuxQ53ugiup/42edVFoQLOnJresoEZLL6WjnsJq4oCTccEAvGhUBI1WWKeZTGNxFQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/rpc-subscriptions-api@2.0.0':
+    resolution: {integrity: sha512-NAJQvSFXYIIf8zxsMFBCkSbZNZgT32pzPZ1V6ZAd+U2iDEjx3L+yFwoJgfOcHp8kAV+alsF2lIsGBlG4u+ehvw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/rpc-subscriptions-channel-websocket@2.0.0':
+    resolution: {integrity: sha512-hSQDZBmcp2t+gLZsSBqs/SqVw4RuNSC7njiP46azyzW7oGg8X2YPV36AHGsHD12KPsc0UpT1OAZ4+AN9meVKww==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5'
+      ws: ^8.18.0
+
+  '@solana/rpc-subscriptions-spec@2.0.0':
+    resolution: {integrity: sha512-VXMiI3fYtU1PkVVTXL87pcY48ZY8aCi1N6FqtxSP2xg/GASL01j1qbwyIL1OvoCqGyRgIxdd/YfaByW9wmWBhA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/rpc-subscriptions@2.0.0':
+    resolution: {integrity: sha512-AdwMJHMrhlj7q1MPjZmVcKq3iLqMW3N0MT8kzIAP2vP+8o/d6Fn4aqGxoz2Hlfn3OYIZoYStN2VBtwzbcfEgMA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/rpc-transformers@2.0.0':
+    resolution: {integrity: sha512-H6tN0qcqzUangowsLLQtYXKJsf1Roe3/qJ1Cy0gv9ojY9uEvNbJqpeEj+7blv0MUZfEe+rECAwBhxxRKPMhYGw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/rpc-transport-http@2.0.0':
+    resolution: {integrity: sha512-UJLhKhhxDd1OPi8hb2AenHsDm1mofCBbhWn4bDCnH2Q3ulwYadUhcNqNbxjJPQ774VNhAf53SSI5A6PQo8IZSQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/rpc-types@2.0.0':
+    resolution: {integrity: sha512-o1ApB9PYR0A3XjVSOh//SOVWgjDcqMlR3UNmtqciuREIBmWqnvPirdOa5EJxD3iPhfA4gnNnhGzT+tMDeDW/Kw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/rpc@2.0.0':
+    resolution: {integrity: sha512-TumQ9DFRpib/RyaIqLVfr7UjqSo7ldfzpae0tgjM93YjbItB4Z0VcUXc3uAFvkeYw2/HIMb46Zg43mkUwozjDg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/signers@2.0.0':
+    resolution: {integrity: sha512-JEYJS3x/iKkqPV/3b1nLpX9lHib21wQKV3fOuu1aDLQqmX9OYKrnIIITYdnFDhmvGhpEpkkbPnqu7yVaFIBYsQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/subscribable@2.0.0':
+    resolution: {integrity: sha512-Ex7d2GnTSNVMZDU3z6nKN4agRDDgCgBDiLnmn1hmt0iFo3alr3gRAqiqa7qGouAtYh9/29pyc8tVJCijHWJPQQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/sysvars@2.0.0':
+    resolution: {integrity: sha512-8D4ajKcCYQsTG1p4k30lre2vjxLR6S5MftUGJnIaQObDCzGmaeA9GRti4Kk4gSPWVYFTBoj1ASx8EcEXaB3eIQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/transaction-confirmation@2.0.0':
+    resolution: {integrity: sha512-JkTw5gXLiqQjf6xK0fpVcoJ/aMp2kagtFSD/BAOazdJ3UYzOzbzqvECt6uWa3ConcMswQ2vXalVtI7ZjmYuIeg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/transaction-messages@2.0.0':
+    resolution: {integrity: sha512-Uc6Fw1EJLBrmgS1lH2ZfLAAKFvprWPQQzOVwZS78Pv8Whsk7tweYTK6S0Upv0nHr50rGpnORJfmdBrXE6OfNGg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/transactions@2.0.0':
+    resolution: {integrity: sha512-VfdTE+59WKvuBG//6iE9RPjAB+ZT2kLgY2CDHabaz6RkH6OjOkMez9fWPVa3Xtcus+YQWN1SnQoryjF/xSx04w==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/web3.js@2.0.0':
+    resolution: {integrity: sha512-x+ZRB2/r5tVK/xw8QRbAfgPcX51G9f2ifEyAQ/J5npOO+6+MPeeCjtr5UxHNDAYs9Ypo0PN+YJATCO4vhzQJGg==}
+    engines: {node: '>=20.18.0'}
+    deprecated: '@solana/web3.js version 2.0 is now @solana/kit! Remove @solana/web3.js@2 from your dependencies and replace it with @solana/kit. As needed, upgrade all of your @solana-program/* dependencies to the latest versions that use Kit.'
+    peerDependencies:
+      typescript: '>=5'
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/node@22.19.15':
+    resolution: {integrity: sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==}
+
+  '@upcoming/multichain-library@0.10.0':
+    resolution: {integrity: sha512-u2DmehBAJCB8ZRIMaTYsngpodx99LqHoF7cpFIjWDCapL4Zu6wRpee2AqHt0OZbzyGSJQorCzeJVUAlcCGff2A==}
+
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
+  '@vitest/mocker@3.2.4':
+    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
+  '@vitest/runner@3.2.4':
+    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+
+  '@vitest/snapshot@3.2.4':
+    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+
+  abitype@1.2.3:
+    resolution: {integrity: sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+      zod: ^3.22.0 || ^4.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+      zod:
+        optional: true
+
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  axios@1.13.6:
+    resolution: {integrity: sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==}
+
+  bundle-require@5.1.0:
+    resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    peerDependencies:
+      esbuild: '>=0.18'
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  cafe-utility@33.8.0:
+    resolution: {integrity: sha512-qfbG8nHTY5jBfCSedG9+b57avhKePdiHfj2w0FMGokJuQU+3dxeT9+qasMReoXHBDp38CFHMSEvz5X0SDCXbWA==}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
+
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
+  commander@12.1.0:
+    resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
+    engines: {node: '>=18'}
+
+  commander@4.1.1:
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
+
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
+
+  esbuild@0.27.4:
+    resolution: {integrity: sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  eventemitter3@5.0.1:
+    resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
+  fastestsmallesttextencoderdecoder@1.0.22:
+    resolution: {integrity: sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fix-dts-default-cjs-exports@1.0.1:
+    resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
+
+  follow-redirects@1.15.11:
+    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.2:
+    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
+  isows@1.0.7:
+    resolution: {integrity: sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==}
+    peerDependencies:
+      ws: '*'
+
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
+
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  load-tsconfig@0.2.5:
+    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  mlly@1.8.2:
+    resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  ox@0.14.5:
+    resolution: {integrity: sha512-HgmHmBveYO40H/R3K6TMrwYtHsx/u6TAB+GpZlgJCoW0Sq5Ttpjih0IZZiwGQw7T6vdW4IAyobYrE2mdAvyF8Q==}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.3:
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
+
+  pirates@4.0.7:
+    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
+    engines: {node: '>= 6'}
+
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  postcss-load-config@6.0.1:
+    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      jiti: '>=1.21.0'
+      postcss: '>=8.0.9'
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+      postcss:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  postcss@8.5.8:
+    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
+  resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
+
+  rollup@4.59.0:
+    resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  source-map@0.7.6:
+    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
+    engines: {node: '>= 12'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
+  sucrase@3.35.1:
+    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
+
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+
+  ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsup@8.5.1:
+    resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7.36.0
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  ufo@1.6.3:
+    resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici-types@6.24.1:
+    resolution: {integrity: sha512-JT8B3M7LYQCRZVfB1OZZIqzi1OMeDHcTpRJpHPNvHFmye4wT03uBM8vw73NqXKfihrpGzSsWlBfUcOglX3oBeA==}
+
+  viem@2.47.5:
+    resolution: {integrity: sha512-nVrJEQ8GL4JoVIrMBF3wwpTUZun0cpojfnOZ+96GtDWhqxZkVdy6vOEgu+jwfXqfTA/+wrR+YsN9TBQmhDUk0g==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite@7.3.1:
+    resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@3.2.4:
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.4
+      '@vitest/ui': 3.2.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  ws@8.18.3:
+    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+snapshots:
+
+  '@adraffy/ens-normalize@1.11.1': {}
+
+  '@esbuild/aix-ppc64@0.27.4':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/android-arm@0.27.4':
+    optional: true
+
+  '@esbuild/android-x64@0.27.4':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.4':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.4':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.4':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.4':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.4':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.4':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.4':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.4':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.4':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.4':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.4':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.4':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.4':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.4':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.4':
+    optional: true
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@noble/ciphers@1.3.0': {}
+
+  '@noble/curves@1.9.1':
+    dependencies:
+      '@noble/hashes': 1.8.0
+
+  '@noble/hashes@1.8.0': {}
+
+  '@relayprotocol/relay-sdk@3.2.0(viem@2.47.5(typescript@5.9.3))':
+    dependencies:
+      axios: 1.13.6
+      viem: 2.47.5(typescript@5.9.3)
+    transitivePeerDependencies:
+      - debug
+
+  '@rollup/rollup-android-arm-eabi@4.59.0':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.59.0':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.59.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.59.0':
+    optional: true
+
+  '@scure/base@1.2.6': {}
+
+  '@scure/bip32@1.7.0':
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.6
+
+  '@scure/bip39@1.6.0':
+    dependencies:
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.6
+
+  '@solana/accounts@2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/codecs-core': 2.0.0(typescript@5.9.3)
+      '@solana/codecs-strings': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/errors': 2.0.0(typescript@5.9.3)
+      '@solana/rpc-spec': 2.0.0(typescript@5.9.3)
+      '@solana/rpc-types': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/addresses@2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/assertions': 2.0.0(typescript@5.9.3)
+      '@solana/codecs-core': 2.0.0(typescript@5.9.3)
+      '@solana/codecs-strings': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/errors': 2.0.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/assertions@2.0.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 2.0.0(typescript@5.9.3)
+      typescript: 5.9.3
+
+  '@solana/codecs-core@2.0.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 2.0.0(typescript@5.9.3)
+      typescript: 5.9.3
+
+  '@solana/codecs-data-structures@2.0.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 2.0.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 2.0.0(typescript@5.9.3)
+      '@solana/errors': 2.0.0(typescript@5.9.3)
+      typescript: 5.9.3
+
+  '@solana/codecs-numbers@2.0.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 2.0.0(typescript@5.9.3)
+      '@solana/errors': 2.0.0(typescript@5.9.3)
+      typescript: 5.9.3
+
+  '@solana/codecs-strings@2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 2.0.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 2.0.0(typescript@5.9.3)
+      '@solana/errors': 2.0.0(typescript@5.9.3)
+      fastestsmallesttextencoderdecoder: 1.0.22
+      typescript: 5.9.3
+
+  '@solana/codecs@2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 2.0.0(typescript@5.9.3)
+      '@solana/codecs-data-structures': 2.0.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 2.0.0(typescript@5.9.3)
+      '@solana/codecs-strings': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/options': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/errors@2.0.0(typescript@5.9.3)':
+    dependencies:
+      chalk: 5.6.2
+      commander: 12.1.0
+      typescript: 5.9.3
+
+  '@solana/fast-stable-stringify@2.0.0(typescript@5.9.3)':
+    dependencies:
+      typescript: 5.9.3
+
+  '@solana/functional@2.0.0(typescript@5.9.3)':
+    dependencies:
+      typescript: 5.9.3
+
+  '@solana/instructions@2.0.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 2.0.0(typescript@5.9.3)
+      typescript: 5.9.3
+
+  '@solana/keys@2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/assertions': 2.0.0(typescript@5.9.3)
+      '@solana/codecs-core': 2.0.0(typescript@5.9.3)
+      '@solana/codecs-strings': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/errors': 2.0.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/options@2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 2.0.0(typescript@5.9.3)
+      '@solana/codecs-data-structures': 2.0.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 2.0.0(typescript@5.9.3)
+      '@solana/codecs-strings': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/errors': 2.0.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/programs@2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/errors': 2.0.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/promises@2.0.0(typescript@5.9.3)':
+    dependencies:
+      typescript: 5.9.3
+
+  '@solana/rpc-api@2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/codecs-core': 2.0.0(typescript@5.9.3)
+      '@solana/codecs-strings': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/errors': 2.0.0(typescript@5.9.3)
+      '@solana/keys': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/rpc-parsed-types': 2.0.0(typescript@5.9.3)
+      '@solana/rpc-spec': 2.0.0(typescript@5.9.3)
+      '@solana/rpc-transformers': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/rpc-types': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transaction-messages': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transactions': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/rpc-parsed-types@2.0.0(typescript@5.9.3)':
+    dependencies:
+      typescript: 5.9.3
+
+  '@solana/rpc-spec-types@2.0.0(typescript@5.9.3)':
+    dependencies:
+      typescript: 5.9.3
+
+  '@solana/rpc-spec@2.0.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 2.0.0(typescript@5.9.3)
+      '@solana/rpc-spec-types': 2.0.0(typescript@5.9.3)
+      typescript: 5.9.3
+
+  '@solana/rpc-subscriptions-api@2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/keys': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/rpc-subscriptions-spec': 2.0.0(typescript@5.9.3)
+      '@solana/rpc-transformers': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/rpc-types': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transaction-messages': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transactions': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/rpc-subscriptions-channel-websocket@2.0.0(typescript@5.9.3)(ws@8.18.3)':
+    dependencies:
+      '@solana/errors': 2.0.0(typescript@5.9.3)
+      '@solana/functional': 2.0.0(typescript@5.9.3)
+      '@solana/rpc-subscriptions-spec': 2.0.0(typescript@5.9.3)
+      '@solana/subscribable': 2.0.0(typescript@5.9.3)
+      typescript: 5.9.3
+      ws: 8.18.3
+
+  '@solana/rpc-subscriptions-spec@2.0.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 2.0.0(typescript@5.9.3)
+      '@solana/promises': 2.0.0(typescript@5.9.3)
+      '@solana/rpc-spec-types': 2.0.0(typescript@5.9.3)
+      '@solana/subscribable': 2.0.0(typescript@5.9.3)
+      typescript: 5.9.3
+
+  '@solana/rpc-subscriptions@2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3)':
+    dependencies:
+      '@solana/errors': 2.0.0(typescript@5.9.3)
+      '@solana/fast-stable-stringify': 2.0.0(typescript@5.9.3)
+      '@solana/functional': 2.0.0(typescript@5.9.3)
+      '@solana/promises': 2.0.0(typescript@5.9.3)
+      '@solana/rpc-spec-types': 2.0.0(typescript@5.9.3)
+      '@solana/rpc-subscriptions-api': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/rpc-subscriptions-channel-websocket': 2.0.0(typescript@5.9.3)(ws@8.18.3)
+      '@solana/rpc-subscriptions-spec': 2.0.0(typescript@5.9.3)
+      '@solana/rpc-transformers': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/rpc-types': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/subscribable': 2.0.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+      - ws
+
+  '@solana/rpc-transformers@2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 2.0.0(typescript@5.9.3)
+      '@solana/functional': 2.0.0(typescript@5.9.3)
+      '@solana/rpc-spec-types': 2.0.0(typescript@5.9.3)
+      '@solana/rpc-types': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/rpc-transport-http@2.0.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 2.0.0(typescript@5.9.3)
+      '@solana/rpc-spec': 2.0.0(typescript@5.9.3)
+      '@solana/rpc-spec-types': 2.0.0(typescript@5.9.3)
+      typescript: 5.9.3
+      undici-types: 6.24.1
+
+  '@solana/rpc-types@2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/codecs-core': 2.0.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 2.0.0(typescript@5.9.3)
+      '@solana/codecs-strings': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/errors': 2.0.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/rpc@2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 2.0.0(typescript@5.9.3)
+      '@solana/fast-stable-stringify': 2.0.0(typescript@5.9.3)
+      '@solana/functional': 2.0.0(typescript@5.9.3)
+      '@solana/rpc-api': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/rpc-spec': 2.0.0(typescript@5.9.3)
+      '@solana/rpc-spec-types': 2.0.0(typescript@5.9.3)
+      '@solana/rpc-transformers': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/rpc-transport-http': 2.0.0(typescript@5.9.3)
+      '@solana/rpc-types': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/signers@2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/codecs-core': 2.0.0(typescript@5.9.3)
+      '@solana/errors': 2.0.0(typescript@5.9.3)
+      '@solana/instructions': 2.0.0(typescript@5.9.3)
+      '@solana/keys': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transaction-messages': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transactions': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/subscribable@2.0.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 2.0.0(typescript@5.9.3)
+      typescript: 5.9.3
+
+  '@solana/sysvars@2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/accounts': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/codecs': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/errors': 2.0.0(typescript@5.9.3)
+      '@solana/rpc-types': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/transaction-confirmation@2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3)':
+    dependencies:
+      '@solana/addresses': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/codecs-strings': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/errors': 2.0.0(typescript@5.9.3)
+      '@solana/keys': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/promises': 2.0.0(typescript@5.9.3)
+      '@solana/rpc': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/rpc-subscriptions': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3)
+      '@solana/rpc-types': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transaction-messages': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transactions': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+      - ws
+
+  '@solana/transaction-messages@2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/codecs-core': 2.0.0(typescript@5.9.3)
+      '@solana/codecs-data-structures': 2.0.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 2.0.0(typescript@5.9.3)
+      '@solana/errors': 2.0.0(typescript@5.9.3)
+      '@solana/functional': 2.0.0(typescript@5.9.3)
+      '@solana/instructions': 2.0.0(typescript@5.9.3)
+      '@solana/rpc-types': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/transactions@2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/codecs-core': 2.0.0(typescript@5.9.3)
+      '@solana/codecs-data-structures': 2.0.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 2.0.0(typescript@5.9.3)
+      '@solana/codecs-strings': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/errors': 2.0.0(typescript@5.9.3)
+      '@solana/functional': 2.0.0(typescript@5.9.3)
+      '@solana/instructions': 2.0.0(typescript@5.9.3)
+      '@solana/keys': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/rpc-types': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transaction-messages': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/web3.js@2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3)':
+    dependencies:
+      '@solana/accounts': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/addresses': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/codecs': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/errors': 2.0.0(typescript@5.9.3)
+      '@solana/functional': 2.0.0(typescript@5.9.3)
+      '@solana/instructions': 2.0.0(typescript@5.9.3)
+      '@solana/keys': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/programs': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/rpc': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/rpc-parsed-types': 2.0.0(typescript@5.9.3)
+      '@solana/rpc-spec-types': 2.0.0(typescript@5.9.3)
+      '@solana/rpc-subscriptions': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3)
+      '@solana/rpc-types': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/signers': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/sysvars': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transaction-confirmation': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3)
+      '@solana/transaction-messages': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transactions': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+      - ws
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.8': {}
+
+  '@types/node@22.19.15':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@upcoming/multichain-library@0.10.0(typescript@5.9.3)':
+    dependencies:
+      cafe-utility: 33.8.0
+      viem: 2.47.5(typescript@5.9.3)
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+      - zod
+
+  '@vitest/expect@3.2.4':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@22.19.15))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.1(@types/node@22.19.15)
+
+  '@vitest/pretty-format@3.2.4':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.4':
+    dependencies:
+      '@vitest/utils': 3.2.4
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
+  '@vitest/snapshot@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.4':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
+
+  abitype@1.2.3(typescript@5.9.3):
+    optionalDependencies:
+      typescript: 5.9.3
+
+  acorn@8.16.0: {}
+
+  any-promise@1.3.0: {}
+
+  assertion-error@2.0.1: {}
+
+  asynckit@0.4.0: {}
+
+  axios@1.13.6:
+    dependencies:
+      follow-redirects: 1.15.11
+      form-data: 4.0.5
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+
+  bundle-require@5.1.0(esbuild@0.27.4):
+    dependencies:
+      esbuild: 0.27.4
+      load-tsconfig: 0.2.5
+
+  cac@6.7.14: {}
+
+  cafe-utility@33.8.0: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
+  chalk@5.6.2: {}
+
+  check-error@2.1.3: {}
+
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
+  commander@12.1.0: {}
+
+  commander@4.1.1: {}
+
+  confbox@0.1.8: {}
+
+  consola@3.4.2: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deep-eql@5.0.2: {}
+
+  delayed-stream@1.0.0: {}
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-module-lexer@1.7.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
+
+  esbuild@0.27.4:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.4
+      '@esbuild/android-arm': 0.27.4
+      '@esbuild/android-arm64': 0.27.4
+      '@esbuild/android-x64': 0.27.4
+      '@esbuild/darwin-arm64': 0.27.4
+      '@esbuild/darwin-x64': 0.27.4
+      '@esbuild/freebsd-arm64': 0.27.4
+      '@esbuild/freebsd-x64': 0.27.4
+      '@esbuild/linux-arm': 0.27.4
+      '@esbuild/linux-arm64': 0.27.4
+      '@esbuild/linux-ia32': 0.27.4
+      '@esbuild/linux-loong64': 0.27.4
+      '@esbuild/linux-mips64el': 0.27.4
+      '@esbuild/linux-ppc64': 0.27.4
+      '@esbuild/linux-riscv64': 0.27.4
+      '@esbuild/linux-s390x': 0.27.4
+      '@esbuild/linux-x64': 0.27.4
+      '@esbuild/netbsd-arm64': 0.27.4
+      '@esbuild/netbsd-x64': 0.27.4
+      '@esbuild/openbsd-arm64': 0.27.4
+      '@esbuild/openbsd-x64': 0.27.4
+      '@esbuild/openharmony-arm64': 0.27.4
+      '@esbuild/sunos-x64': 0.27.4
+      '@esbuild/win32-arm64': 0.27.4
+      '@esbuild/win32-ia32': 0.27.4
+      '@esbuild/win32-x64': 0.27.4
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  eventemitter3@5.0.1: {}
+
+  expect-type@1.3.0: {}
+
+  fastestsmallesttextencoderdecoder@1.0.22: {}
+
+  fdir@6.5.0(picomatch@4.0.3):
+    optionalDependencies:
+      picomatch: 4.0.3
+
+  fix-dts-default-cjs-exports@1.0.1:
+    dependencies:
+      magic-string: 0.30.21
+      mlly: 1.8.2
+      rollup: 4.59.0
+
+  follow-redirects@1.15.11: {}
+
+  form-data@4.0.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
+
+  fsevents@2.3.3:
+    optional: true
+
+  function-bind@1.1.2: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
+
+  gopd@1.2.0: {}
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
+  hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
+
+  isows@1.0.7(ws@8.18.3):
+    dependencies:
+      ws: 8.18.3
+
+  joycon@3.1.1: {}
+
+  js-tokens@9.0.1: {}
+
+  lilconfig@3.1.3: {}
+
+  lines-and-columns@1.2.4: {}
+
+  load-tsconfig@0.2.5: {}
+
+  loupe@3.2.1: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  math-intrinsics@1.1.0: {}
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
+  mlly@1.8.2:
+    dependencies:
+      acorn: 8.16.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.3
+
+  ms@2.1.3: {}
+
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
+
+  nanoid@3.3.11: {}
+
+  object-assign@4.1.1: {}
+
+  ox@0.14.5(typescript@5.9.3):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.9.3)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - zod
+
+  pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.3: {}
+
+  pirates@4.0.7: {}
+
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.2
+      pathe: 2.0.3
+
+  postcss-load-config@6.0.1(postcss@8.5.8):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      postcss: 8.5.8
+
+  postcss@8.5.8:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  proxy-from-env@1.1.0: {}
+
+  readdirp@4.1.2: {}
+
+  resolve-from@5.0.0: {}
+
+  rollup@4.59.0:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.59.0
+      '@rollup/rollup-android-arm64': 4.59.0
+      '@rollup/rollup-darwin-arm64': 4.59.0
+      '@rollup/rollup-darwin-x64': 4.59.0
+      '@rollup/rollup-freebsd-arm64': 4.59.0
+      '@rollup/rollup-freebsd-x64': 4.59.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.59.0
+      '@rollup/rollup-linux-arm-musleabihf': 4.59.0
+      '@rollup/rollup-linux-arm64-gnu': 4.59.0
+      '@rollup/rollup-linux-arm64-musl': 4.59.0
+      '@rollup/rollup-linux-loong64-gnu': 4.59.0
+      '@rollup/rollup-linux-loong64-musl': 4.59.0
+      '@rollup/rollup-linux-ppc64-gnu': 4.59.0
+      '@rollup/rollup-linux-ppc64-musl': 4.59.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.59.0
+      '@rollup/rollup-linux-riscv64-musl': 4.59.0
+      '@rollup/rollup-linux-s390x-gnu': 4.59.0
+      '@rollup/rollup-linux-x64-gnu': 4.59.0
+      '@rollup/rollup-linux-x64-musl': 4.59.0
+      '@rollup/rollup-openbsd-x64': 4.59.0
+      '@rollup/rollup-openharmony-arm64': 4.59.0
+      '@rollup/rollup-win32-arm64-msvc': 4.59.0
+      '@rollup/rollup-win32-ia32-msvc': 4.59.0
+      '@rollup/rollup-win32-x64-gnu': 4.59.0
+      '@rollup/rollup-win32-x64-msvc': 4.59.0
+      fsevents: 2.3.3
+
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  source-map@0.7.6: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
+
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
+
+  sucrase@3.35.1:
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      commander: 4.1.1
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.7
+      tinyglobby: 0.2.15
+      ts-interface-checker: 0.1.13
+
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
+
+  tree-kill@1.2.2: {}
+
+  ts-interface-checker@0.1.13: {}
+
+  tslib@2.8.1: {}
+
+  tsup@8.5.1(postcss@8.5.8)(typescript@5.9.3):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.27.4)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.3
+      esbuild: 0.27.4
+      fix-dts-default-cjs-exports: 1.0.1
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(postcss@8.5.8)
+      resolve-from: 5.0.0
+      rollup: 4.59.0
+      source-map: 0.7.6
+      sucrase: 3.35.1
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tree-kill: 1.2.2
+    optionalDependencies:
+      postcss: 8.5.8
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
+
+  typescript@5.9.3: {}
+
+  ufo@1.6.3: {}
+
+  undici-types@6.21.0: {}
+
+  undici-types@6.24.1: {}
+
+  viem@2.47.5(typescript@5.9.3):
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.9.3)
+      isows: 1.0.7(ws@8.18.3)
+      ox: 0.14.5(typescript@5.9.3)
+      ws: 8.18.3
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+
+  vite-node@3.2.4(@types/node@22.19.15):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.1(@types/node@22.19.15)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@7.3.1(@types/node@22.19.15):
+    dependencies:
+      esbuild: 0.27.4
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.8
+      rollup: 4.59.0
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 22.19.15
+      fsevents: 2.3.3
+
+  vitest@3.2.4(@types/node@22.19.15):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@22.19.15))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.1(@types/node@22.19.15)
+      vite-node: 3.2.4(@types/node@22.19.15)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.15
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  ws@8.18.3: {}

--- a/src/MultichainSDK.ts
+++ b/src/MultichainSDK.ts
@@ -1,0 +1,310 @@
+import { MultichainLibrary, xBZZ, xDAI } from '@upcoming/multichain-library'
+import { Elliptic, Strings } from 'cafe-utility'
+import { SUPPORTED_CHAINS, getStampCost } from './config'
+import { ConfigurationError, PriceFetchError } from './errors'
+import { createFundingFlow, createBatchFlow, executeFlow, executeBatchFlow } from './flows/EvmToGnosisFlow'
+import { RelayProvider } from './providers/RelayProvider'
+import type {
+  BatchRequest,
+  BatchResult,
+  EvmWalletAdapter,
+  MultichainSDKOptions,
+  SwapCallbacks,
+  SwapQuote,
+  SwapRequest,
+  SwapResult,
+} from './types'
+
+/**
+ * Main SDK class for cross-chain swaps to Gnosis and Swarm postage batch creation.
+ *
+ * @example
+ * ```typescript
+ * import { MultichainSDK, EvmPrivateKeyWallet } from '@upcoming/multichain-sdk'
+ *
+ * const sdk = new MultichainSDK()
+ * const wallet = new EvmPrivateKeyWallet({ privateKey: '0x...', chainId: 8453 })
+ *
+ * // Fund a wallet with xBZZ + xDAI
+ * const result = await sdk.swap({
+ *   wallet, sourceChain: 8453, targetAddress: '0xBeeNode...',
+ *   bzzAmount: 10, nativeAmount: 0.5
+ * })
+ *
+ * // Create a postage batch
+ * const batch = await sdk.createBatch({
+ *   wallet, sourceChain: 8453, targetAddress: '0xBeeNode...',
+ *   batchDepth: 20, batchDurationDays: 30
+ * })
+ * ```
+ */
+export class MultichainSDK {
+  private library: MultichainLibrary
+  private relayProvider: RelayProvider
+  private mocked: boolean
+
+  constructor(options?: MultichainSDKOptions) {
+    this.library = new MultichainLibrary(options?.librarySettings)
+    this.relayProvider = new RelayProvider()
+    this.mocked = options?.mocked ?? false
+  }
+
+  /**
+   * Get a quote for a cross-chain swap without executing it.
+   * Use this to preview costs before committing funds.
+   */
+  async getQuote(request: SwapRequest): Promise<SwapQuote> {
+    this.validateRequest(request)
+
+    const bzzAmount = request.bzzAmount ?? 0
+    const nativeAmount = request.nativeAmount ?? 0
+    const sourceToken = request.sourceToken ?? this.library.constants.nullAddress
+
+    let bzzUsdPrice = 0
+    let bzzUsdValue = 0
+    if (bzzAmount > 0) {
+      try {
+        bzzUsdPrice = await this.library.getGnosisBzzTokenPrice()
+      } catch (error) {
+        throw new PriceFetchError('BZZ price', error instanceof Error ? error : undefined)
+      }
+      const neededBzz = xBZZ.fromFloat(bzzAmount)
+      bzzUsdValue = neededBzz.toFloat() * bzzUsdPrice
+    }
+
+    const daiDust = this.library.constants.daiDustAmount.toFloat()
+    const totalNeededUsdValue = (bzzUsdValue + nativeAmount + daiDust) * 1.1
+
+    const { temporaryPrivateKey, temporaryAddress } = this.generateTemporaryWallet()
+    const sourceAddress = await request.wallet.getAddress()
+
+    const { relayQuote, sourceTokenAmount, totalDaiValue } = await this.relayProvider.getQuote({
+      sourceAddress,
+      temporaryAddress,
+      sourceChain: request.sourceChain,
+      sourceToken,
+      totalNeededUsdValue,
+      library: this.library,
+    })
+
+    const currencyIn = relayQuote?.details?.currencyIn
+    const estimatedUsdValue =
+      currencyIn?.amountUsd ? parseFloat(currencyIn.amountUsd) : sourceTokenAmount.toFloat()
+
+    return {
+      relayQuote,
+      sourceTokenAmount,
+      estimatedUsdValue,
+      totalDaiValue,
+      bzzUsdPrice,
+      bzzUsdValue,
+      nativeAmount,
+      temporaryAddress,
+      temporaryPrivateKey,
+      request,
+    }
+  }
+
+  /**
+   * Execute a swap from a previously obtained quote.
+   */
+  async executeSwap(
+    quote: SwapQuote,
+    wallet: EvmWalletAdapter,
+    callbacks?: SwapCallbacks,
+  ): Promise<SwapResult> {
+    const sourceToken = quote.request.sourceToken ?? this.library.constants.nullAddress
+    const metadata: Record<string, string> = {}
+
+    const onMetadata = (key: string, value: string) => {
+      metadata[key] = value
+      callbacks?.onMetadata?.(key, value)
+    }
+
+    const walletClient = await wallet.getWalletClient()
+    const sendTransactionAsync = async (tx: { to: `0x${string}`; value: bigint }) => {
+      return wallet.sendTransaction(tx)
+    }
+
+    const solver = createFundingFlow({
+      library: this.library,
+      relayQuote: quote.relayQuote,
+      sourceChain: quote.request.sourceChain,
+      sourceToken,
+      sourceTokenAmount: quote.sourceTokenAmount,
+      sendTransactionAsync,
+      targetAddress: quote.request.targetAddress,
+      temporaryAddress: quote.temporaryAddress,
+      temporaryPrivateKey: quote.temporaryPrivateKey,
+      bzzUsdValue: quote.bzzUsdValue,
+      totalDaiValue: quote.totalDaiValue,
+      relayClient: this.relayProvider.getClient(),
+      walletClient,
+      mocked: this.mocked,
+      onMetadata,
+    })
+
+    const result = await executeFlow(
+      solver,
+      { temporaryPrivateKey: quote.temporaryPrivateKey, temporaryAddress: quote.temporaryAddress },
+      callbacks,
+    )
+    result.metadata = { ...result.metadata, ...metadata }
+    return result
+  }
+
+  /**
+   * One-step convenience: quote and execute a swap in one call.
+   * Delivers xBZZ and/or xDAI to the target address on Gnosis.
+   */
+  async swap(request: SwapRequest, callbacks?: SwapCallbacks): Promise<SwapResult> {
+    const quote = await this.getQuote(request)
+    return this.executeSwap(quote, request.wallet, callbacks)
+  }
+
+  /**
+   * Cross-chain swap + Swarm postage batch creation in one operation.
+   * SDK auto-calculates required xBZZ from batch parameters.
+   */
+  async createBatch(request: BatchRequest, callbacks?: SwapCallbacks): Promise<BatchResult> {
+    this.validateRequest(request)
+
+    const sourceToken = request.sourceToken ?? this.library.constants.nullAddress
+
+    let bzzUsdPrice: number
+    try {
+      bzzUsdPrice = await this.library.getGnosisBzzTokenPrice()
+    } catch (error) {
+      throw new PriceFetchError('BZZ price', error instanceof Error ? error : undefined)
+    }
+
+    let storagePrice: bigint
+    try {
+      storagePrice = await this.library.getStoragePriceGnosis()
+    } catch (error) {
+      throw new PriceFetchError('storage price', error instanceof Error ? error : undefined)
+    }
+
+    const stampCost = getStampCost(request.batchDepth, request.batchDurationDays, storagePrice)
+    const bzzUsdValue = stampCost.bzz.toFloat() * bzzUsdPrice
+    const nativeAmount = request.nativeAmount ?? 0
+    const daiDust = this.library.constants.daiDustAmount.toFloat()
+    const totalNeededUsdValue = (bzzUsdValue + nativeAmount + daiDust) * 1.1
+
+    const { temporaryPrivateKey, temporaryAddress } = this.generateTemporaryWallet()
+    const sourceAddress = await request.wallet.getAddress()
+
+    const { relayQuote, sourceTokenAmount, totalDaiValue } = await this.relayProvider.getQuote({
+      sourceAddress,
+      temporaryAddress,
+      sourceChain: request.sourceChain,
+      sourceToken,
+      totalNeededUsdValue,
+      library: this.library,
+    })
+
+    const walletClient = await request.wallet.getWalletClient()
+    const sendTransactionAsync = async (tx: { to: `0x${string}`; value: bigint }) => {
+      return request.wallet.sendTransaction(tx)
+    }
+
+    const metadata: Record<string, string> = {}
+    const onMetadata = (key: string, value: string) => {
+      metadata[key] = value
+      callbacks?.onMetadata?.(key, value)
+    }
+
+    let batchResult: { batchId: string; depth: number; amount: string; blockNumber: string } | undefined
+    const onBatchCreated = (data: { batchId: string; depth: number; amount: string; blockNumber: string }) => {
+      batchResult = data
+      callbacks?.onBatchCreated?.(data)
+    }
+
+    const solver = createBatchFlow({
+      library: this.library,
+      relayQuote,
+      sourceChain: request.sourceChain,
+      sourceToken,
+      sourceTokenAmount,
+      sendTransactionAsync,
+      targetAddress: request.targetAddress,
+      temporaryAddress,
+      temporaryPrivateKey,
+      bzzUsdValue,
+      totalDaiValue,
+      relayClient: this.relayProvider.getClient(),
+      walletClient,
+      batchAmount: stampCost.amount,
+      batchDepth: request.batchDepth,
+      mocked: this.mocked,
+      onMetadata,
+      onBatchCreated,
+    })
+
+    const result = await executeBatchFlow(
+      solver,
+      { temporaryPrivateKey, temporaryAddress },
+      callbacks,
+    )
+    result.metadata = { ...result.metadata, ...metadata }
+
+    if (batchResult) {
+      result.batchId = batchResult.batchId
+      result.blockNumber = batchResult.blockNumber
+    }
+
+    return result
+  }
+
+  /** Get current BZZ/USD price */
+  async getBzzPrice(): Promise<number> {
+    try {
+      return await this.library.getGnosisBzzTokenPrice()
+    } catch (error) {
+      throw new PriceFetchError('BZZ price', error instanceof Error ? error : undefined)
+    }
+  }
+
+  /** Get current Gnosis storage price per block */
+  async getStoragePrice(): Promise<bigint> {
+    try {
+      return await this.library.getStoragePriceGnosis()
+    } catch (error) {
+      throw new PriceFetchError('storage price', error instanceof Error ? error : undefined)
+    }
+  }
+
+  private validateRequest(request: SwapRequest): void {
+    if (!(request.sourceChain in SUPPORTED_CHAINS)) {
+      throw new ConfigurationError(
+        `Unsupported source chain: ${request.sourceChain}. Supported chains: 1 (Ethereum), 137 (Polygon), 10 (Optimism), 42161 (Arbitrum), 8453 (Base).`
+      )
+    }
+
+    const bzzAmount = request.bzzAmount ?? 0
+    const nativeAmount = request.nativeAmount ?? 0
+
+    if ('batchDepth' in request) {
+      // BatchRequest — amounts are calculated from batch params, skip amount check
+      return
+    }
+
+    if (bzzAmount <= 0 && nativeAmount <= 0) {
+      throw new ConfigurationError(
+        'At least one of bzzAmount or nativeAmount must be greater than 0.'
+      )
+    }
+  }
+
+  private generateTemporaryWallet(): { temporaryPrivateKey: `0x${string}`; temporaryAddress: `0x${string}` } {
+    const hex = Strings.randomHex(64)
+    const privateKeyBigInt = BigInt(`0x${hex}`)
+    const publicKey = Elliptic.privateKeyToPublicKey(privateKeyBigInt)
+    const addressBytes = Elliptic.publicKeyToAddress(publicKey)
+    const address = Elliptic.checksumEncode(addressBytes)
+    return {
+      temporaryPrivateKey: `0x${hex}`,
+      temporaryAddress: address as `0x${string}`,
+    }
+  }
+}

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+import { getExplorerTxUrl, getStampCost, SUPPORTED_CHAINS } from '../config'
+
+describe('Config', () => {
+  describe('SUPPORTED_CHAINS', () => {
+    it('contains all 5 source chains', () => {
+      expect(Object.keys(SUPPORTED_CHAINS)).toHaveLength(5)
+      expect(SUPPORTED_CHAINS[1]).toBeDefined()
+      expect(SUPPORTED_CHAINS[137]).toBeDefined()
+      expect(SUPPORTED_CHAINS[10]).toBeDefined()
+      expect(SUPPORTED_CHAINS[42161]).toBeDefined()
+      expect(SUPPORTED_CHAINS[8453]).toBeDefined()
+    })
+
+    it('chains have correct IDs', () => {
+      expect(SUPPORTED_CHAINS[1].id).toBe(1)
+      expect(SUPPORTED_CHAINS[137].id).toBe(137)
+      expect(SUPPORTED_CHAINS[10].id).toBe(10)
+      expect(SUPPORTED_CHAINS[42161].id).toBe(42161)
+      expect(SUPPORTED_CHAINS[8453].id).toBe(8453)
+    })
+  })
+
+  describe('getExplorerTxUrl', () => {
+    it('returns correct URL for Ethereum', () => {
+      expect(getExplorerTxUrl(1, '0xabc')).toBe('https://etherscan.io/tx/0xabc')
+    })
+
+    it('returns correct URL for Gnosis', () => {
+      expect(getExplorerTxUrl(100, '0xdef')).toBe('https://gnosisscan.io/tx/0xdef')
+    })
+
+    it('returns correct URL for Polygon', () => {
+      expect(getExplorerTxUrl(137, '0x123')).toBe('https://polygonscan.com/tx/0x123')
+    })
+
+    it('returns correct URL for Optimism', () => {
+      expect(getExplorerTxUrl(10, '0x456')).toBe('https://optimistic.etherscan.io/tx/0x456')
+    })
+
+    it('returns correct URL for Arbitrum', () => {
+      expect(getExplorerTxUrl(42161, '0x789')).toBe('https://arbiscan.io/tx/0x789')
+    })
+
+    it('returns correct URL for Base', () => {
+      expect(getExplorerTxUrl(8453, '0xfoo')).toBe('https://basescan.org/tx/0xfoo')
+    })
+
+    it('falls back to etherscan for unknown chains', () => {
+      expect(getExplorerTxUrl(99999, '0xbar')).toBe('https://etherscan.io/tx/0xbar')
+    })
+  })
+
+  describe('getStampCost', () => {
+    it('calculates stamp cost for known inputs', () => {
+      const storagePrice = 24000n
+      const result = getStampCost(20, 30, storagePrice)
+      // amount = (30 * 86_400 / 5) * 24000 + 1 = 518400 * 24000 + 1 = 12441600001
+      const expectedAmount = (BigInt(30 * 86_400) / 5n) * storagePrice + 1n
+      expect(result.amount).toBe(expectedAmount)
+      // bzz = 2^20 * amount (with 16 decimals as FixedPointNumber)
+      expect(result.bzz).toBeDefined()
+      expect(result.bzz.value).toBe(2n ** 20n * expectedAmount)
+    })
+
+    it('handles zero days', () => {
+      const result = getStampCost(17, 0, 24000n)
+      expect(result.amount).toBe(1n)
+    })
+  })
+})

--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest'
+import {
+  MultichainError,
+  NoRouteError,
+  InsufficientBalanceError,
+  TransactionRejectedError,
+  StepExecutionError,
+  QuoteExpiredError,
+  ConfigurationError,
+  PriceFetchError,
+} from '../errors'
+
+describe('Error classes', () => {
+  it('MultichainError has correct code and is instanceof Error', () => {
+    const err = new MultichainError('test', 'TEST_CODE')
+    expect(err.code).toBe('TEST_CODE')
+    expect(err.message).toBe('test')
+    expect(err).toBeInstanceOf(Error)
+    expect(err).toBeInstanceOf(MultichainError)
+  })
+
+  it('MultichainError preserves cause', () => {
+    const cause = new Error('root cause')
+    const err = new MultichainError('test', 'TEST', cause)
+    expect(err.cause).toBe(cause)
+  })
+
+  it('NoRouteError has NO_ROUTE code', () => {
+    const err = new NoRouteError(8453, '0x0000000000000000000000000000000000000000')
+    expect(err.code).toBe('NO_ROUTE')
+    expect(err).toBeInstanceOf(MultichainError)
+    expect(err).toBeInstanceOf(NoRouteError)
+    expect(err.message).toContain('8453')
+  })
+
+  it('InsufficientBalanceError has INSUFFICIENT_BALANCE code', () => {
+    const err = new InsufficientBalanceError('1.5', '0.5', 'ETH')
+    expect(err.code).toBe('INSUFFICIENT_BALANCE')
+    expect(err).toBeInstanceOf(MultichainError)
+    expect(err.message).toContain('1.5')
+    expect(err.message).toContain('0.5')
+    expect(err.message).toContain('ETH')
+  })
+
+  it('TransactionRejectedError has TRANSACTION_REJECTED code', () => {
+    const err = new TransactionRejectedError()
+    expect(err.code).toBe('TRANSACTION_REJECTED')
+    expect(err).toBeInstanceOf(MultichainError)
+  })
+
+  it('StepExecutionError has STEP_FAILED code and stepName', () => {
+    const err = new StepExecutionError('relay')
+    expect(err.code).toBe('STEP_FAILED')
+    expect(err.stepName).toBe('relay')
+    expect(err).toBeInstanceOf(MultichainError)
+    expect(err.message).toContain('relay')
+    expect(err.message).toContain('temporaryPrivateKey')
+  })
+
+  it('QuoteExpiredError has QUOTE_EXPIRED code', () => {
+    const err = new QuoteExpiredError()
+    expect(err.code).toBe('QUOTE_EXPIRED')
+    expect(err).toBeInstanceOf(MultichainError)
+  })
+
+  it('ConfigurationError has CONFIGURATION_ERROR code', () => {
+    const err = new ConfigurationError('bad chain')
+    expect(err.code).toBe('CONFIGURATION_ERROR')
+    expect(err).toBeInstanceOf(MultichainError)
+    expect(err.message).toBe('bad chain')
+  })
+
+  it('PriceFetchError has PRICE_FETCH_FAILED code', () => {
+    const cause = new Error('timeout')
+    const err = new PriceFetchError('BZZ price', cause)
+    expect(err.code).toBe('PRICE_FETCH_FAILED')
+    expect(err).toBeInstanceOf(MultichainError)
+    expect(err.cause).toBe(cause)
+  })
+
+  it('errors can be caught with instanceof in catch blocks', () => {
+    try {
+      throw new NoRouteError(1, '0x0')
+    } catch (error) {
+      expect(error).toBeInstanceOf(NoRouteError)
+      expect(error).toBeInstanceOf(MultichainError)
+      expect(error).toBeInstanceOf(Error)
+    }
+  })
+})

--- a/src/__tests__/exports.test.ts
+++ b/src/__tests__/exports.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import * as sdk from '../index'
+
+describe('Barrel exports', () => {
+  it('exports MultichainSDK class', () => {
+    expect(sdk.MultichainSDK).toBeDefined()
+    expect(typeof sdk.MultichainSDK).toBe('function')
+  })
+
+  it('exports wallet adapters', () => {
+    expect(sdk.EvmPrivateKeyWallet).toBeDefined()
+    expect(sdk.EvmWalletClientAdapter).toBeDefined()
+  })
+
+  it('exports all error classes', () => {
+    expect(sdk.MultichainError).toBeDefined()
+    expect(sdk.NoRouteError).toBeDefined()
+    expect(sdk.InsufficientBalanceError).toBeDefined()
+    expect(sdk.TransactionRejectedError).toBeDefined()
+    expect(sdk.StepExecutionError).toBeDefined()
+    expect(sdk.QuoteExpiredError).toBeDefined()
+    expect(sdk.ConfigurationError).toBeDefined()
+    expect(sdk.PriceFetchError).toBeDefined()
+  })
+
+  it('exports config utilities', () => {
+    expect(sdk.SUPPORTED_CHAINS).toBeDefined()
+    expect(sdk.DEFAULT_RPC_URLS).toBeDefined()
+    expect(typeof sdk.getExplorerTxUrl).toBe('function')
+  })
+
+  it('error classes extend MultichainError', () => {
+    expect(new sdk.NoRouteError(1, '0x0')).toBeInstanceOf(sdk.MultichainError)
+    expect(new sdk.ConfigurationError('test')).toBeInstanceOf(sdk.MultichainError)
+    expect(new sdk.PriceFetchError('test')).toBeInstanceOf(sdk.MultichainError)
+    expect(new sdk.StepExecutionError('test')).toBeInstanceOf(sdk.MultichainError)
+    expect(new sdk.QuoteExpiredError()).toBeInstanceOf(sdk.MultichainError)
+    expect(new sdk.TransactionRejectedError()).toBeInstanceOf(sdk.MultichainError)
+    expect(new sdk.InsufficientBalanceError('1', '0', 'ETH')).toBeInstanceOf(sdk.MultichainError)
+  })
+})

--- a/src/__tests__/sdk.test.ts
+++ b/src/__tests__/sdk.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, it, vi } from 'vitest'
+import { MultichainSDK } from '../MultichainSDK'
+import { ConfigurationError } from '../errors'
+import type { EvmWalletAdapter, StepStatus } from '../types'
+
+function createMockWallet(): EvmWalletAdapter {
+  return {
+    type: 'evm',
+    getAddress: async () => '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266' as `0x${string}`,
+    getChainId: async () => 8453,
+    sendTransaction: async () => '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef' as `0x${string}`,
+    getWalletClient: async () => ({} as any),
+  }
+}
+
+describe('MultichainSDK', () => {
+  describe('constructor', () => {
+    it('creates instance with default options', () => {
+      const sdk = new MultichainSDK()
+      expect(sdk).toBeInstanceOf(MultichainSDK)
+    })
+
+    it('creates instance with mocked mode', () => {
+      const sdk = new MultichainSDK({ mocked: true })
+      expect(sdk).toBeInstanceOf(MultichainSDK)
+    })
+  })
+
+  describe('swap (mocked)', () => {
+    it('completes funding flow with all 6 steps', async () => {
+      const sdk = new MultichainSDK({ mocked: true })
+      const wallet = createMockWallet()
+      const stepChanges: Record<string, StepStatus>[] = []
+
+      const result = await sdk.swap(
+        {
+          wallet,
+          sourceChain: 8453,
+          targetAddress: '0x1234567890123456789012345678901234567890',
+          bzzAmount: 10,
+          nativeAmount: 0.5,
+        },
+        {
+          onStepChange: (steps) => {
+            stepChanges.push({ ...steps })
+          },
+        },
+      )
+
+      expect(result.temporaryPrivateKey).toMatch(/^0x[0-9a-f]{64}$/)
+      expect(result.temporaryAddress).toMatch(/^0x[0-9a-fA-F]{40}$/)
+      expect(result.steps).toBeDefined()
+      expect(result.metadata).toBeDefined()
+
+      // Verify all 6 step names are present
+      const stepNames = Object.keys(result.steps)
+      expect(stepNames).toContain('relay')
+      expect(stepNames).toContain('relay-sync')
+      expect(stepNames).toContain('sushi')
+      expect(stepNames).toContain('sushi-sync')
+      expect(stepNames).toContain('transfer')
+      expect(stepNames).toContain('transfer-sync')
+    }, 30000)
+
+    it('fires onStatusChange callbacks', async () => {
+      const sdk = new MultichainSDK({ mocked: true })
+      const wallet = createMockWallet()
+      const statuses: string[] = []
+
+      await sdk.swap(
+        {
+          wallet,
+          sourceChain: 8453,
+          targetAddress: '0x1234567890123456789012345678901234567890',
+          bzzAmount: 5,
+        },
+        {
+          onStatusChange: (status) => {
+            statuses.push(status)
+          },
+        },
+      )
+
+      expect(statuses).toContain('in-progress')
+      expect(statuses).toContain('completed')
+    }, 30000)
+  })
+
+  describe('createBatch (mocked)', () => {
+    it('completes batch flow with 8 steps and returns batchId', async () => {
+      const sdk = new MultichainSDK({ mocked: true })
+      const wallet = createMockWallet()
+
+      const result = await sdk.createBatch(
+        {
+          wallet,
+          sourceChain: 8453,
+          targetAddress: '0x1234567890123456789012345678901234567890',
+          batchDepth: 20,
+          batchDurationDays: 30,
+        },
+        {
+          onBatchCreated: (data) => {
+            expect(data.batchId).toBeDefined()
+            expect(data.depth).toBe(20)
+          },
+        },
+      )
+
+      expect(result.batchId).toMatch(/^0x[0-9a-f]{64}$/)
+      expect(result.temporaryPrivateKey).toMatch(/^0x[0-9a-f]{64}$/)
+
+      // Verify all 8 step names are present
+      const stepNames = Object.keys(result.steps)
+      expect(stepNames).toContain('relay')
+      expect(stepNames).toContain('relay-sync')
+      expect(stepNames).toContain('sushi')
+      expect(stepNames).toContain('sushi-sync')
+      expect(stepNames).toContain('approve-bzz')
+      expect(stepNames).toContain('create-batch')
+      expect(stepNames).toContain('transfer')
+      expect(stepNames).toContain('transfer-sync')
+    }, 30000)
+  })
+
+  describe('swap edge cases (mocked)', () => {
+    it('completes with bzzAmount only (no nativeAmount)', async () => {
+      const sdk = new MultichainSDK({ mocked: true })
+      const wallet = createMockWallet()
+
+      const result = await sdk.swap({
+        wallet,
+        sourceChain: 8453,
+        targetAddress: '0x1234567890123456789012345678901234567890',
+        bzzAmount: 5,
+      })
+
+      expect(result.temporaryPrivateKey).toMatch(/^0x[0-9a-f]{64}$/)
+      expect(result.steps).toBeDefined()
+    }, 30000)
+
+    it('completes with nativeAmount only (no bzzAmount)', async () => {
+      const sdk = new MultichainSDK({ mocked: true })
+      const wallet = createMockWallet()
+
+      const result = await sdk.swap({
+        wallet,
+        sourceChain: 8453,
+        targetAddress: '0x1234567890123456789012345678901234567890',
+        nativeAmount: 1.0,
+      })
+
+      expect(result.temporaryPrivateKey).toMatch(/^0x[0-9a-f]{64}$/)
+      expect(result.steps).toBeDefined()
+    }, 30000)
+
+    it('generates unique temporary wallets per call', async () => {
+      const sdk = new MultichainSDK({ mocked: true })
+      const wallet = createMockWallet()
+      const request = {
+        wallet,
+        sourceChain: 8453 as const,
+        targetAddress: '0x1234567890123456789012345678901234567890' as `0x${string}`,
+        bzzAmount: 1,
+      }
+
+      const result1 = await sdk.swap(request)
+      const result2 = await sdk.swap(request)
+
+      expect(result1.temporaryPrivateKey).not.toBe(result2.temporaryPrivateKey)
+      expect(result1.temporaryAddress).not.toBe(result2.temporaryAddress)
+    }, 60000)
+
+    it('works with all supported source chains', async () => {
+      const sdk = new MultichainSDK({ mocked: true })
+      const wallet = createMockWallet()
+
+      for (const chain of [1, 137, 10, 42161, 8453] as const) {
+        const result = await sdk.swap({
+          wallet,
+          sourceChain: chain,
+          targetAddress: '0x1234567890123456789012345678901234567890',
+          bzzAmount: 1,
+        })
+        expect(result.steps).toBeDefined()
+      }
+    }, 120000)
+  })
+
+  describe('validation', () => {
+    it('rejects unsupported source chain', async () => {
+      const sdk = new MultichainSDK({ mocked: true })
+      const wallet = createMockWallet()
+
+      await expect(
+        sdk.swap({
+          wallet,
+          sourceChain: 999 as any,
+          targetAddress: '0x1234567890123456789012345678901234567890',
+          bzzAmount: 1,
+        }),
+      ).rejects.toThrow(ConfigurationError)
+    })
+
+    it('rejects when both amounts are zero', async () => {
+      const sdk = new MultichainSDK({ mocked: true })
+      const wallet = createMockWallet()
+
+      await expect(
+        sdk.swap({
+          wallet,
+          sourceChain: 8453,
+          targetAddress: '0x1234567890123456789012345678901234567890',
+          bzzAmount: 0,
+          nativeAmount: 0,
+        }),
+      ).rejects.toThrow(ConfigurationError)
+    })
+
+    it('rejects when no amounts specified', async () => {
+      const sdk = new MultichainSDK({ mocked: true })
+      const wallet = createMockWallet()
+
+      await expect(
+        sdk.swap({
+          wallet,
+          sourceChain: 8453,
+          targetAddress: '0x1234567890123456789012345678901234567890',
+        }),
+      ).rejects.toThrow(ConfigurationError)
+    })
+  })
+})

--- a/src/__tests__/wallets.test.ts
+++ b/src/__tests__/wallets.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest'
+import { createWalletClient, http } from 'viem'
+import { privateKeyToAccount } from 'viem/accounts'
+import { base, mainnet } from 'viem/chains'
+import { EvmPrivateKeyWallet } from '../wallets/EvmPrivateKeyWallet'
+import { EvmWalletClientAdapter } from '../wallets/EvmWalletClientAdapter'
+
+// Well-known test private key (Hardhat account #0)
+const testKey = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80' as const
+const expectedAddress = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'
+
+describe('EvmPrivateKeyWallet', () => {
+  it('derives correct address from known private key', async () => {
+    const wallet = new EvmPrivateKeyWallet({ privateKey: testKey, chainId: 8453 })
+    const address = await wallet.getAddress()
+    expect(address.toLowerCase()).toBe(expectedAddress.toLowerCase())
+  })
+
+  it('returns correct chain ID', async () => {
+    const wallet = new EvmPrivateKeyWallet({ privateKey: testKey, chainId: 8453 })
+    const chainId = await wallet.getChainId()
+    expect(chainId).toBe(8453)
+  })
+
+  it('has type evm', () => {
+    const wallet = new EvmPrivateKeyWallet({ privateKey: testKey, chainId: 1 })
+    expect(wallet.type).toBe('evm')
+  })
+
+  it('returns a WalletClient', async () => {
+    const wallet = new EvmPrivateKeyWallet({ privateKey: testKey, chainId: 8453 })
+    const client = await wallet.getWalletClient()
+    expect(client).toBeDefined()
+    expect(client.chain!.id).toBe(8453)
+  })
+
+  it('works with all supported chain IDs', async () => {
+    for (const chainId of [1, 137, 10, 42161, 8453] as const) {
+      const wallet = new EvmPrivateKeyWallet({ privateKey: testKey, chainId })
+      expect(await wallet.getChainId()).toBe(chainId)
+    }
+  })
+
+  it('accepts custom RPC URL', async () => {
+    const wallet = new EvmPrivateKeyWallet({
+      privateKey: testKey,
+      chainId: 8453,
+      rpcUrl: 'https://custom-rpc.example.com',
+    })
+    expect(await wallet.getAddress()).toBeTruthy()
+  })
+})
+
+describe('EvmWalletClientAdapter', () => {
+  const account = privateKeyToAccount(testKey)
+
+  it('wraps viem WalletClient and returns correct address', async () => {
+    const client = createWalletClient({
+      account,
+      chain: base,
+      transport: http(),
+    })
+    const adapter = new EvmWalletClientAdapter(client)
+    const address = await adapter.getAddress()
+    expect(address.toLowerCase()).toBe(expectedAddress.toLowerCase())
+  })
+
+  it('returns correct chain ID from underlying client', async () => {
+    const client = createWalletClient({
+      account,
+      chain: mainnet,
+      transport: http(),
+    })
+    const adapter = new EvmWalletClientAdapter(client)
+    expect(await adapter.getChainId()).toBe(1)
+  })
+
+  it('has type evm', () => {
+    const client = createWalletClient({
+      account,
+      chain: base,
+      transport: http(),
+    })
+    const adapter = new EvmWalletClientAdapter(client)
+    expect(adapter.type).toBe('evm')
+  })
+
+  it('returns the original WalletClient', async () => {
+    const client = createWalletClient({
+      account,
+      chain: base,
+      transport: http(),
+    })
+    const adapter = new EvmWalletClientAdapter(client)
+    const returned = await adapter.getWalletClient()
+    expect(returned).toBe(client)
+  })
+})

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,63 @@
+import { convertViemChainToRelayChain } from '@relayprotocol/relay-sdk'
+import { FixedPointNumber } from 'cafe-utility'
+import { type Chain } from 'viem'
+import { arbitrum, base, gnosis, mainnet, optimism, polygon } from 'viem/chains'
+import type { SupportedChainId } from './types'
+
+/** Supported source chains mapped to viem Chain objects */
+export const SUPPORTED_CHAINS: Record<SupportedChainId, Chain> = {
+  1: mainnet,
+  137: polygon,
+  10: optimism,
+  42161: arbitrum,
+  8453: base,
+}
+
+/** Default RPC URLs for each chain (matching widget defaults) */
+export const DEFAULT_RPC_URLS: Record<SupportedChainId | 100, string> = {
+  1: 'https://ethereum-rpc.publicnode.com',
+  137: 'https://polygon.drpc.org',
+  10: 'https://optimism.drpc.org',
+  42161: 'https://arbitrum.drpc.org',
+  8453: 'https://base.drpc.org',
+  100: 'https://xdai.fairdatasociety.org',
+}
+
+/** Block explorer base URLs */
+const EXPLORER_URLS: Record<number, string> = {
+  1: 'https://etherscan.io',
+  100: 'https://gnosisscan.io',
+  137: 'https://polygonscan.com',
+  10: 'https://optimistic.etherscan.io',
+  42161: 'https://arbiscan.io',
+  8453: 'https://basescan.org',
+}
+
+/** Build a full explorer transaction URL */
+export function getExplorerTxUrl(chainId: number, txHash: string): string {
+  const base = EXPLORER_URLS[chainId] || 'https://etherscan.io'
+  return `${base}/tx/${txHash}`
+}
+
+/** Get Relay Protocol chain configurations */
+export function getRelayChains() {
+  return [mainnet, polygon, optimism, arbitrum, base, gnosis].map(convertViemChainToRelayChain)
+}
+
+/** Stamp cost calculation result */
+export interface StampCost {
+  bzz: FixedPointNumber
+  amount: bigint
+}
+
+/**
+ * Calculate the cost of a postage batch.
+ * Adapted from widget's Utility.ts.
+ */
+export function getStampCost(depth: number, days: number, storagePrice: bigint): StampCost {
+  const amount = (BigInt(days * 86_400) / BigInt(5)) * storagePrice + 1n
+  return {
+    bzz: new FixedPointNumber(2n ** BigInt(depth) * BigInt(amount), 16),
+    amount,
+  }
+}

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,94 @@
+/** Base error class for all SDK errors with machine-readable code */
+export class MultichainError extends Error {
+  readonly code: string
+  readonly cause?: Error
+
+  constructor(message: string, code: string, cause?: Error) {
+    super(message)
+    this.name = 'MultichainError'
+    this.code = code
+    this.cause = cause
+  }
+}
+
+/** Relay Protocol found no routes for the requested swap */
+export class NoRouteError extends MultichainError {
+  constructor(sourceChain: number, sourceToken: string, cause?: Error) {
+    super(
+      `No route found from chain ${sourceChain} (token ${sourceToken}) to Gnosis. ` +
+      `Try a different source chain or token.`,
+      'NO_ROUTE',
+      cause
+    )
+    this.name = 'NoRouteError'
+  }
+}
+
+/** Source wallet does not have enough tokens to cover the swap */
+export class InsufficientBalanceError extends MultichainError {
+  constructor(required: string, available: string, symbol: string) {
+    super(
+      `Insufficient balance: need ${required} ${symbol} but only ${available} available.`,
+      'INSUFFICIENT_BALANCE'
+    )
+    this.name = 'InsufficientBalanceError'
+  }
+}
+
+/** Wallet rejected the transaction signing request */
+export class TransactionRejectedError extends MultichainError {
+  constructor(cause?: Error) {
+    super(
+      'Transaction was rejected by the wallet. The user or wallet provider denied signing.',
+      'TRANSACTION_REJECTED',
+      cause
+    )
+    this.name = 'TransactionRejectedError'
+  }
+}
+
+/** A flow step failed during execution */
+export class StepExecutionError extends MultichainError {
+  readonly stepName: string
+
+  constructor(stepName: string, cause?: Error) {
+    super(
+      `Step "${stepName}" failed. If funds were bridged, use the temporaryPrivateKey from the result to recover them.`,
+      'STEP_FAILED',
+      cause
+    )
+    this.name = 'StepExecutionError'
+    this.stepName = stepName
+  }
+}
+
+/** Quote was used after its expiry window */
+export class QuoteExpiredError extends MultichainError {
+  constructor() {
+    super(
+      'The swap quote has expired. Please request a new quote.',
+      'QUOTE_EXPIRED'
+    )
+    this.name = 'QuoteExpiredError'
+  }
+}
+
+/** Invalid configuration (unsupported chain, missing parameters, etc.) */
+export class ConfigurationError extends MultichainError {
+  constructor(message: string) {
+    super(message, 'CONFIGURATION_ERROR')
+    this.name = 'ConfigurationError'
+  }
+}
+
+/** Failed to fetch BZZ price or storage price */
+export class PriceFetchError extends MultichainError {
+  constructor(what: string, cause?: Error) {
+    super(
+      `Failed to fetch ${what}. The price API may be temporarily unavailable.`,
+      'PRICE_FETCH_FAILED',
+      cause
+    )
+    this.name = 'PriceFetchError'
+  }
+}

--- a/src/flows/EvmToGnosisFlow.ts
+++ b/src/flows/EvmToGnosisFlow.ts
@@ -1,0 +1,166 @@
+import { Execute, RelayClient } from '@relayprotocol/relay-sdk'
+import { MultichainLibrary } from '@upcoming/multichain-library'
+import { FixedPointNumber, Solver } from 'cafe-utility'
+import { WalletClient } from 'viem'
+import type { SendTransactionSignature } from '../steps/RelayStep'
+import { createRelayStep } from '../steps/RelayStep'
+import { createRelaySyncStep } from '../steps/RelaySyncStep'
+import { createSushiStep } from '../steps/SushiStep'
+import { createSushiSyncStep } from '../steps/SushiSyncStep'
+import { createTransferStep } from '../steps/TransferStep'
+import { createTransferSyncStep } from '../steps/TransferSyncStep'
+import { createApproveBzzStep } from '../steps/ApproveBzzStep'
+import { createCreateBatchStep } from '../steps/CreateBatchStep'
+import { createMockedRelayStep } from '../steps/MockedRelayStep'
+import { createMockedRelaySyncStep } from '../steps/MockedRelaySyncStep'
+import { createMockedSushiStep } from '../steps/MockedSushiStep'
+import { createMockedSushiSyncStep } from '../steps/MockedSushiSyncStep'
+import { createMockedTransferStep } from '../steps/MockedTransferStep'
+import { createMockedTransferSyncStep } from '../steps/MockedTransferSyncStep'
+import { createMockedApproveBzzStep } from '../steps/MockedApproveBzzStep'
+import { createMockedCreateBatchStep } from '../steps/MockedCreateBatchStep'
+import type { StepStatus, SwapCallbacks, SwapResult, BatchResult } from '../types'
+
+interface FundingFlowOptions {
+  library: MultichainLibrary
+  sourceChain: number
+  sourceToken: string
+  sourceTokenAmount: FixedPointNumber
+  totalDaiValue: FixedPointNumber
+  bzzUsdValue: number
+  temporaryAddress: `0x${string}`
+  temporaryPrivateKey: `0x${string}`
+  targetAddress: `0x${string}`
+  sendTransactionAsync: SendTransactionSignature
+  relayClient: RelayClient
+  walletClient: WalletClient
+  relayQuote: Execute
+  mocked: boolean
+  onMetadata: (key: string, value: string) => void
+}
+
+interface BatchFlowOptions extends FundingFlowOptions {
+  batchAmount: string | bigint
+  batchDepth: number
+  onBatchCreated?: (data: { batchId: string; depth: number; amount: string; blockNumber: string }) => void
+}
+
+export function createFundingFlow(options: FundingFlowOptions): Solver {
+  const solver = new Solver()
+
+  if (options.mocked) {
+    solver.addStep(createMockedRelayStep())
+    solver.addStep(createMockedRelaySyncStep())
+    solver.addStep(createMockedSushiStep())
+    solver.addStep(createMockedSushiSyncStep())
+    solver.addStep(createMockedTransferStep())
+    solver.addStep(createMockedTransferSyncStep())
+  } else {
+    solver.addStep(createRelayStep(options))
+    solver.addStep(createRelaySyncStep(options))
+    solver.addStep(createSushiStep(options))
+    solver.addStep(createSushiSyncStep(options))
+    solver.addStep(createTransferStep(options))
+    solver.addStep(createTransferSyncStep(options))
+  }
+
+  return solver
+}
+
+export function createBatchFlow(options: BatchFlowOptions): Solver {
+  const solver = new Solver()
+
+  if (options.mocked) {
+    solver.addStep(createMockedRelayStep())
+    solver.addStep(createMockedRelaySyncStep())
+    solver.addStep(createMockedSushiStep())
+    solver.addStep(createMockedSushiSyncStep())
+    solver.addStep(createMockedApproveBzzStep())
+    solver.addStep(createMockedCreateBatchStep(options))
+    solver.addStep(createMockedTransferStep())
+    solver.addStep(createMockedTransferSyncStep())
+  } else {
+    solver.addStep(createRelayStep(options))
+    solver.addStep(createRelaySyncStep(options))
+    solver.addStep(createSushiStep({ ...options, targetAddress: options.temporaryAddress }))
+    solver.addStep(createSushiSyncStep({ ...options, targetAddress: options.temporaryAddress }))
+    solver.addStep(createApproveBzzStep(options))
+    solver.addStep(createCreateBatchStep(options))
+    solver.addStep(createTransferStep(options))
+    solver.addStep(createTransferSyncStep(options))
+  }
+
+  return solver
+}
+
+export async function executeFlow(
+  solver: Solver,
+  options: { temporaryPrivateKey: `0x${string}`; temporaryAddress: `0x${string}` },
+  callbacks?: SwapCallbacks,
+): Promise<SwapResult> {
+  const metadata: Record<string, string> = {}
+  let stepStates: Record<string, StepStatus> = {}
+
+  solver.setHooks({
+    onStatusChange: async (newStatus) => {
+      callbacks?.onStatusChange?.(newStatus as 'pending' | 'in-progress' | 'completed' | 'failed')
+    },
+    onStepChange: async (newStepStates) => {
+      stepStates = newStepStates as Record<string, StepStatus>
+      callbacks?.onStepChange?.(stepStates)
+    },
+    onError: async (error) => {
+      callbacks?.onError?.(error instanceof Error ? error : new Error(String(error)))
+    },
+    onFinish: async () => {},
+  })
+
+  await solver.execute()
+
+  return {
+    steps: stepStates,
+    metadata,
+    temporaryPrivateKey: options.temporaryPrivateKey,
+    temporaryAddress: options.temporaryAddress,
+  }
+}
+
+export async function executeBatchFlow(
+  solver: Solver,
+  options: { temporaryPrivateKey: `0x${string}`; temporaryAddress: `0x${string}` },
+  callbacks?: SwapCallbacks,
+): Promise<BatchResult> {
+  const metadata: Record<string, string> = {}
+  let stepStates: Record<string, StepStatus> = {}
+  let batchId = ''
+  let blockNumber = ''
+
+  solver.setHooks({
+    onStatusChange: async (newStatus) => {
+      callbacks?.onStatusChange?.(newStatus as 'pending' | 'in-progress' | 'completed' | 'failed')
+    },
+    onStepChange: async (newStepStates) => {
+      stepStates = newStepStates as Record<string, StepStatus>
+      callbacks?.onStepChange?.(stepStates)
+    },
+    onError: async (error) => {
+      callbacks?.onError?.(error instanceof Error ? error : new Error(String(error)))
+    },
+    onFinish: async () => {},
+  })
+
+  const context = await solver.execute()
+
+  if (context.has('batchId')) {
+    batchId = context.get('batchId') as string
+  }
+
+  return {
+    steps: stepStates,
+    metadata,
+    temporaryPrivateKey: options.temporaryPrivateKey,
+    temporaryAddress: options.temporaryAddress,
+    batchId,
+    blockNumber,
+  }
+}

--- a/src/flows/SolanaToGnosisFlow.ts
+++ b/src/flows/SolanaToGnosisFlow.ts
@@ -1,0 +1,10 @@
+/**
+ * Solana → Gnosis flow via deBridge DLN — Phase 4 stub.
+ */
+export function createSolanaFundingFlow(): never {
+  throw new Error('Solana → Gnosis flow is not yet implemented (Phase 4)')
+}
+
+export function createSolanaBatchFlow(): never {
+  throw new Error('Solana → Gnosis batch flow is not yet implemented (Phase 4)')
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,26 @@
+export { MultichainSDK } from './MultichainSDK'
+export type {
+  EvmWalletAdapter,
+  SwapRequest,
+  BatchRequest,
+  SwapQuote,
+  SwapResult,
+  BatchResult,
+  SwapCallbacks,
+  MultichainSDKOptions,
+  SupportedChainId,
+  StepStatus,
+} from './types'
+export { EvmPrivateKeyWallet } from './wallets/EvmPrivateKeyWallet'
+export { EvmWalletClientAdapter } from './wallets/EvmWalletClientAdapter'
+export {
+  MultichainError,
+  NoRouteError,
+  InsufficientBalanceError,
+  TransactionRejectedError,
+  StepExecutionError,
+  QuoteExpiredError,
+  ConfigurationError,
+  PriceFetchError,
+} from './errors'
+export { SUPPORTED_CHAINS, DEFAULT_RPC_URLS, getExplorerTxUrl } from './config'

--- a/src/providers/DeBridgeProvider.ts
+++ b/src/providers/DeBridgeProvider.ts
@@ -1,0 +1,8 @@
+/**
+ * deBridge DLN provider for Solana → Gnosis swaps — Phase 4 stub.
+ */
+export class DeBridgeProvider {
+  constructor() {
+    throw new Error('deBridge provider is not yet implemented (Phase 4)')
+  }
+}

--- a/src/providers/RelayProvider.ts
+++ b/src/providers/RelayProvider.ts
@@ -1,0 +1,62 @@
+import { createClient, Execute, RelayClient } from '@relayprotocol/relay-sdk'
+import { MultichainLibrary, xDAI } from '@upcoming/multichain-library'
+import { FixedPointNumber, Objects } from 'cafe-utility'
+import { getRelayChains } from '../config'
+import { NoRouteError } from '../errors'
+
+interface QuoteParams {
+  sourceAddress: `0x${string}`
+  temporaryAddress: `0x${string}`
+  sourceChain: number
+  sourceToken: string
+  totalNeededUsdValue: number
+  library: MultichainLibrary
+}
+
+interface QuoteResult {
+  relayQuote: Execute
+  sourceTokenAmount: FixedPointNumber
+  totalDaiValue: FixedPointNumber
+}
+
+export class RelayProvider {
+  private client: RelayClient
+
+  constructor() {
+    this.client = createClient({ chains: getRelayChains() })
+  }
+
+  getClient(): RelayClient {
+    return this.client
+  }
+
+  async getQuote(params: QuoteParams): Promise<QuoteResult> {
+    const totalDaiValue = xDAI.fromFloat(params.totalNeededUsdValue)
+    const quoteConfiguration = {
+      user: params.sourceAddress,
+      recipient: params.temporaryAddress,
+      chainId: params.sourceChain,
+      toChainId: params.library.constants.gnosisChainId,
+      currency: params.sourceToken,
+      toCurrency: params.library.constants.nullAddress,
+      tradeType: 'EXACT_OUTPUT' as const,
+      amount: totalDaiValue.toString(),
+    }
+
+    try {
+      const quote = await this.client.actions.getQuote(quoteConfiguration)
+      const currencyIn = quote?.details?.currencyIn
+      const sourceTokenAmount =
+        currencyIn?.amount && currencyIn.currency?.decimals
+          ? new FixedPointNumber(currencyIn.amount, currencyIn.currency.decimals)
+          : new FixedPointNumber(0n, 18)
+
+      return { relayQuote: quote, sourceTokenAmount, totalDaiValue }
+    } catch (error: unknown) {
+      if (Objects.errorMatches(error, 'no routes found')) {
+        throw new NoRouteError(params.sourceChain, params.sourceToken, error instanceof Error ? error : undefined)
+      }
+      throw error
+    }
+  }
+}

--- a/src/steps/ApproveBzzStep.ts
+++ b/src/steps/ApproveBzzStep.ts
@@ -1,0 +1,25 @@
+import { MultichainLibrary, xBZZ } from '@upcoming/multichain-library'
+
+interface Options {
+  library: MultichainLibrary
+  temporaryAddress: `0x${string}`
+  temporaryPrivateKey: `0x${string}`
+  onMetadata: (key: string, value: string) => void
+}
+
+export function createApproveBzzStep(options: Options) {
+  return {
+    name: 'approve-bzz',
+    action: async (context: Map<string, unknown>) => {
+      const nonce = await options.library.getGnosisTransactionCount(options.temporaryAddress)
+      context.set('nonce', nonce)
+      const tx = await options.library.approveGnosisBzz({
+        amount: xBZZ.fromDecimalString('1000').toString(),
+        spender: options.library.constants.postageStampGnosisAddress,
+        originPrivateKey: options.temporaryPrivateKey,
+        nonce,
+      })
+      options.onMetadata('approve', `https://gnosisscan.io/tx/${tx}`)
+    },
+  }
+}

--- a/src/steps/CreateBatchStep.ts
+++ b/src/steps/CreateBatchStep.ts
@@ -1,0 +1,42 @@
+import { MultichainLibrary } from '@upcoming/multichain-library'
+import { Strings, Types } from 'cafe-utility'
+
+interface Options {
+  library: MultichainLibrary
+  temporaryPrivateKey: `0x${string}`
+  targetAddress: `0x${string}`
+  batchAmount: string | bigint
+  batchDepth: number
+  onMetadata: (key: string, value: string) => void
+  onBatchCreated?: (data: { batchId: string; depth: number; amount: string; blockNumber: string }) => void
+}
+
+export function createCreateBatchStep(options: Options) {
+  return {
+    name: 'create-batch',
+    action: async (context: Map<string, unknown>) => {
+      const nonce = Types.asNumber(context.get('nonce'))
+      const result = await options.library.createBatchGnosis({
+        amount: options.batchAmount,
+        depth: options.batchDepth,
+        originPrivateKey: options.temporaryPrivateKey,
+        immutable: false,
+        batchNonce: `0x${Strings.randomHex(64)}` as `0x${string}`,
+        bucketDepth: 16,
+        owner: Types.asHexString(options.targetAddress),
+        nonce: nonce + 1,
+      })
+      const transaction = await options.library.getGnosisTransaction(result.transactionHash)
+      options.onMetadata('batch', `https://gnosisscan.io/tx/${result.transactionHash}`)
+      const message = {
+        batchId: result.batchId,
+        depth: options.batchDepth,
+        amount: options.batchAmount.toString(),
+        blockNumber: transaction.blockNumber,
+      }
+      console.log('Postage batch created', message)
+      options.onBatchCreated?.(message)
+      context.set('batchId', result.batchId)
+    },
+  }
+}

--- a/src/steps/MockedApproveBzzStep.ts
+++ b/src/steps/MockedApproveBzzStep.ts
@@ -1,0 +1,10 @@
+import { System } from 'cafe-utility'
+
+export function createMockedApproveBzzStep() {
+  return {
+    name: 'approve-bzz',
+    action: async (_context: Map<string, unknown>) => {
+      await System.sleepMillis(500)
+    },
+  }
+}

--- a/src/steps/MockedCreateBatchStep.ts
+++ b/src/steps/MockedCreateBatchStep.ts
@@ -1,0 +1,26 @@
+import { Strings, System } from 'cafe-utility'
+
+interface Options {
+  batchAmount: string | bigint
+  batchDepth: number
+  onBatchCreated?: (data: { batchId: string; depth: number; amount: string; blockNumber: string }) => void
+}
+
+export function createMockedCreateBatchStep(options: Options) {
+  return {
+    name: 'create-batch',
+    action: async (context: Map<string, unknown>) => {
+      await System.sleepMillis(500)
+      const batchId = `0x${Strings.randomHex(64)}`
+      const message = {
+        batchId,
+        depth: options.batchDepth,
+        amount: options.batchAmount.toString(),
+        blockNumber: '0x2aa1944',
+      }
+      console.log('Postage batch created', message)
+      options.onBatchCreated?.(message)
+      context.set('batchId', batchId)
+    },
+  }
+}

--- a/src/steps/MockedRelayStep.ts
+++ b/src/steps/MockedRelayStep.ts
@@ -1,0 +1,10 @@
+import { System } from 'cafe-utility'
+
+export function createMockedRelayStep() {
+  return {
+    name: 'relay',
+    action: async (_context: Map<string, unknown>) => {
+      await System.sleepMillis(500)
+    },
+  }
+}

--- a/src/steps/MockedRelaySyncStep.ts
+++ b/src/steps/MockedRelaySyncStep.ts
@@ -1,0 +1,10 @@
+import { System } from 'cafe-utility'
+
+export function createMockedRelaySyncStep() {
+  return {
+    name: 'relay-sync',
+    action: async (_context: Map<string, unknown>) => {
+      await System.sleepMillis(500)
+    },
+  }
+}

--- a/src/steps/MockedSushiStep.ts
+++ b/src/steps/MockedSushiStep.ts
@@ -1,0 +1,10 @@
+import { System } from 'cafe-utility'
+
+export function createMockedSushiStep() {
+  return {
+    name: 'sushi',
+    action: async (_context: Map<string, unknown>) => {
+      await System.sleepMillis(500)
+    },
+  }
+}

--- a/src/steps/MockedSushiSyncStep.ts
+++ b/src/steps/MockedSushiSyncStep.ts
@@ -1,0 +1,10 @@
+import { System } from 'cafe-utility'
+
+export function createMockedSushiSyncStep() {
+  return {
+    name: 'sushi-sync',
+    action: async (_context: Map<string, unknown>) => {
+      await System.sleepMillis(500)
+    },
+  }
+}

--- a/src/steps/MockedTransferStep.ts
+++ b/src/steps/MockedTransferStep.ts
@@ -1,0 +1,10 @@
+import { System } from 'cafe-utility'
+
+export function createMockedTransferStep() {
+  return {
+    name: 'transfer',
+    action: async (_context: Map<string, unknown>) => {
+      await System.sleepMillis(500)
+    },
+  }
+}

--- a/src/steps/MockedTransferSyncStep.ts
+++ b/src/steps/MockedTransferSyncStep.ts
@@ -1,0 +1,11 @@
+import { System } from 'cafe-utility'
+
+export function createMockedTransferSyncStep() {
+  return {
+    name: 'transfer-sync',
+    transientSkipStepName: 'transfer',
+    action: async (_context: Map<string, unknown>) => {
+      await System.sleepMillis(500)
+    },
+  }
+}

--- a/src/steps/RelayStep.ts
+++ b/src/steps/RelayStep.ts
@@ -1,0 +1,59 @@
+import { Execute, ProgressData, RelayClient } from '@relayprotocol/relay-sdk'
+import { MultichainLibrary } from '@upcoming/multichain-library'
+import { FixedPointNumber } from 'cafe-utility'
+import { WalletClient } from 'viem'
+import { getExplorerTxUrl } from '../config'
+
+export type SendTransactionSignature = (tx: { to: `0x${string}`; value: bigint }) => Promise<`0x${string}`>
+
+interface Options {
+  library: MultichainLibrary
+  sourceChain: number
+  sourceToken: string
+  temporaryAddress: `0x${string}`
+  sourceTokenAmount: FixedPointNumber
+  sendTransactionAsync: SendTransactionSignature
+  relayClient: RelayClient
+  walletClient: WalletClient
+  relayQuote: Execute
+  totalDaiValue: FixedPointNumber
+  onMetadata: (key: string, value: string) => void
+}
+
+export function createRelayStep(options: Options) {
+  return {
+    name: 'relay',
+    precondition: async () => {
+      const dai = await options.library.getGnosisNativeBalance(options.temporaryAddress)
+      return dai.value < options.totalDaiValue.value
+    },
+    action: async (context: Map<string, unknown>) => {
+      const daiBefore = await options.library.getGnosisNativeBalance(options.temporaryAddress)
+      context.set('daiBefore', daiBefore)
+      if (
+        options.sourceToken === options.library.constants.nullAddress &&
+        options.sourceChain === options.library.constants.gnosisChainId
+      ) {
+        const tx = await options.sendTransactionAsync({
+          to: options.temporaryAddress,
+          value: options.sourceTokenAmount.value,
+        })
+        options.onMetadata('relay', `https://gnosisscan.io/tx/${tx}`)
+      } else {
+        await options.relayClient.actions.execute({
+          quote: options.relayQuote,
+          wallet: options.walletClient,
+          onProgress: (data: ProgressData) => {
+            console.log('Relay progress data', data)
+            if (data.txHashes) {
+              const txHash = data.txHashes.find(x => x.txHash.length >= 64)
+              if (txHash) {
+                options.onMetadata('relay', getExplorerTxUrl(txHash.chainId, txHash.txHash))
+              }
+            }
+          },
+        })
+      }
+    },
+  }
+}

--- a/src/steps/RelaySyncStep.ts
+++ b/src/steps/RelaySyncStep.ts
@@ -1,0 +1,17 @@
+import { MultichainLibrary, xDAI } from '@upcoming/multichain-library'
+
+interface Options {
+  library: MultichainLibrary
+  temporaryAddress: `0x${string}`
+}
+
+export function createRelaySyncStep(options: Options) {
+  return {
+    name: 'relay-sync',
+    transientSkipStepName: 'relay',
+    action: async (context: Map<string, unknown>) => {
+      const daiBefore = xDAI.cast(context.get('daiBefore'))
+      await options.library.waitForGnosisNativeBalanceToIncrease(options.temporaryAddress, daiBefore.value)
+    },
+  }
+}

--- a/src/steps/SushiStep.ts
+++ b/src/steps/SushiStep.ts
@@ -1,0 +1,44 @@
+import { MultichainLibrary, xDAI } from '@upcoming/multichain-library'
+
+interface Options {
+  library: MultichainLibrary
+  bzzUsdValue: number
+  temporaryAddress: `0x${string}`
+  temporaryPrivateKey: `0x${string}`
+  targetAddress: `0x${string}`
+  onMetadata: (key: string, value: string) => void
+}
+
+export function createSushiStep(options: Options) {
+  return {
+    name: 'sushi',
+    precondition: async () => {
+      return options.bzzUsdValue > 0
+    },
+    action: async (context: Map<string, unknown>, zeroIndexedAttemptNumber: number) => {
+      const daiBefore = await options.library.getGnosisNativeBalance(options.temporaryAddress)
+      const bzzBefore = await options.library.getGnosisBzzBalance(options.targetAddress)
+      context.set('daiBefore', daiBefore)
+      context.set('bzzBefore', bzzBefore)
+      const plannedDai = xDAI.fromFloat(options.bzzUsdValue)
+      const amount =
+        daiBefore.subtract(options.library.constants.daiDustAmount).compare(plannedDai) === -1
+          ? daiBefore.subtract(options.library.constants.daiDustAmount)
+          : plannedDai
+      const tx = await options.library.swapOnGnosisAuto({
+        amount: amount.toString(),
+        originPrivateKey: options.temporaryPrivateKey,
+        to: options.targetAddress,
+      })
+      options.onMetadata('sushi', `https://gnosisscan.io/tx/${tx}`)
+      try {
+        await options.library.waitForGnosisTransactionReceipt(tx)
+      } catch (error) {
+        if (zeroIndexedAttemptNumber === 0) {
+          return 'retry' as const
+        }
+        throw error
+      }
+    },
+  }
+}

--- a/src/steps/SushiSyncStep.ts
+++ b/src/steps/SushiSyncStep.ts
@@ -1,0 +1,20 @@
+import { MultichainLibrary, xBZZ, xDAI } from '@upcoming/multichain-library'
+
+interface Options {
+  library: MultichainLibrary
+  temporaryAddress: `0x${string}`
+  targetAddress: `0x${string}`
+}
+
+export function createSushiSyncStep(options: Options) {
+  return {
+    name: 'sushi-sync',
+    transientSkipStepName: 'sushi',
+    action: async (context: Map<string, unknown>) => {
+      const daiBefore = xDAI.cast(context.get('daiBefore'))
+      const bzzBefore = xBZZ.cast(context.get('bzzBefore'))
+      await options.library.waitForGnosisBzzBalanceToIncrease(options.targetAddress, bzzBefore.value)
+      await options.library.waitForGnosisNativeBalanceToDecrease(options.temporaryAddress, daiBefore.value)
+    },
+  }
+}

--- a/src/steps/TransferStep.ts
+++ b/src/steps/TransferStep.ts
@@ -1,0 +1,38 @@
+import { MultichainLibrary } from '@upcoming/multichain-library'
+
+interface Options {
+  library: MultichainLibrary
+  temporaryAddress: `0x${string}`
+  temporaryPrivateKey: `0x${string}`
+  targetAddress: `0x${string}`
+  onMetadata: (key: string, value: string) => void
+}
+
+export function createTransferStep(options: Options) {
+  return {
+    name: 'transfer',
+    precondition: async () => {
+      const dai = await options.library.getGnosisNativeBalance(options.temporaryAddress)
+      const amountToTransfer = dai.subtract(options.library.constants.daiDustAmount)
+      return amountToTransfer.value > options.library.constants.daiDustAmount.value
+    },
+    action: async (context: Map<string, unknown>, zeroIndexedAttemptNumber: number) => {
+      const daiBefore = await options.library.getGnosisNativeBalance(options.temporaryAddress)
+      context.set('daiBefore', daiBefore)
+      const tx = await options.library.transferGnosisNative({
+        originPrivateKey: options.temporaryPrivateKey,
+        to: options.targetAddress,
+        amount: daiBefore.subtract(options.library.constants.daiDustAmount).toString(),
+      })
+      options.onMetadata('transfer', `https://gnosisscan.io/tx/${tx}`)
+      try {
+        await options.library.waitForGnosisTransactionReceipt(tx)
+      } catch (error) {
+        if (zeroIndexedAttemptNumber === 0) {
+          return 'retry' as const
+        }
+        throw error
+      }
+    },
+  }
+}

--- a/src/steps/TransferSyncStep.ts
+++ b/src/steps/TransferSyncStep.ts
@@ -1,0 +1,17 @@
+import { MultichainLibrary, xDAI } from '@upcoming/multichain-library'
+
+interface Options {
+  library: MultichainLibrary
+  temporaryAddress: `0x${string}`
+}
+
+export function createTransferSyncStep(options: Options) {
+  return {
+    name: 'transfer-sync',
+    transientSkipStepName: 'transfer',
+    action: async (context: Map<string, unknown>) => {
+      const daiBefore = xDAI.cast(context.get('daiBefore'))
+      await options.library.waitForGnosisNativeBalanceToDecrease(options.temporaryAddress, daiBefore.value)
+    },
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,117 @@
+import type { Execute } from '@relayprotocol/relay-sdk'
+import type { MultichainLibrarySettings } from '@upcoming/multichain-library'
+import type { FixedPointNumber } from 'cafe-utility'
+import type { WalletClient } from 'viem'
+
+/** Supported EVM source chains */
+export type SupportedChainId = 1 | 137 | 10 | 42161 | 8453
+
+/** Status of an individual step in a flow */
+export type StepStatus = 'pending' | 'in-progress' | 'completed' | 'failed' | 'skipped'
+
+/** Minimal wallet interface that any EVM wallet provider can implement */
+export interface EvmWalletAdapter {
+  type: 'evm'
+  getAddress(): Promise<`0x${string}`>
+  getChainId(): Promise<number>
+  sendTransaction(tx: { to: `0x${string}`; value: bigint }): Promise<`0x${string}`>
+  getWalletClient(): Promise<WalletClient>
+}
+
+/**
+ * Request to swap tokens cross-chain and deliver xBZZ and/or xDAI to a target address.
+ * At least one of `bzzAmount` or `nativeAmount` must be > 0.
+ */
+export interface SwapRequest {
+  /** Wallet adapter providing the source funds */
+  wallet: EvmWalletAdapter
+  /** Source chain ID (1=Ethereum, 137=Polygon, 10=Optimism, 42161=Arbitrum, 8453=Base) */
+  sourceChain: SupportedChainId
+  /** Gnosis address to receive xBZZ and/or xDAI */
+  targetAddress: `0x${string}`
+  /** Amount of xBZZ to deliver (in BZZ units, e.g. 10 = 10 BZZ). Defaults to 0. */
+  bzzAmount?: number
+  /** Amount of xDAI to deliver (in DAI units, e.g. 0.5 = 0.5 DAI). Defaults to 0. */
+  nativeAmount?: number
+  /** Source token address. Defaults to native token (null address). */
+  sourceToken?: `0x${string}`
+}
+
+/**
+ * Request to swap tokens cross-chain and create a Swarm postage batch.
+ * SDK auto-calculates required xBZZ from batch parameters.
+ */
+export interface BatchRequest extends SwapRequest {
+  /** Batch depth (determines storage capacity) */
+  batchDepth: number
+  /** Batch duration in days */
+  batchDurationDays: number
+}
+
+/** Quote for a cross-chain swap */
+export interface SwapQuote {
+  /** Opaque Relay Protocol quote object */
+  relayQuote: Execute
+  /** Amount of source tokens needed */
+  sourceTokenAmount: FixedPointNumber
+  /** Estimated USD value of the swap */
+  estimatedUsdValue: number
+  /** Total xDAI value being bridged (including slippage buffer) */
+  totalDaiValue: FixedPointNumber
+  /** Current BZZ/USD price */
+  bzzUsdPrice: number
+  /** BZZ USD value portion of the swap */
+  bzzUsdValue: number
+  /** Native (xDAI) amount requested */
+  nativeAmount: number
+  /** Temporary address on Gnosis that receives bridged funds */
+  temporaryAddress: `0x${string}`
+  /** Private key for the temporary address (for fund recovery) */
+  temporaryPrivateKey: `0x${string}`
+  /** The original swap request */
+  request: SwapRequest
+}
+
+/** Result of a completed swap operation */
+export interface SwapResult {
+  /** Step status map (step name → final status) */
+  steps: Record<string, StepStatus>
+  /** Metadata collected during execution (explorer URLs, etc.) */
+  metadata: Record<string, string>
+  /** Temporary wallet private key (for fund recovery if flow failed) */
+  temporaryPrivateKey: `0x${string}`
+  /** Temporary wallet address */
+  temporaryAddress: `0x${string}`
+}
+
+/** Result of a completed batch creation operation */
+export interface BatchResult extends SwapResult {
+  /** Created postage batch ID */
+  batchId: string
+  /** Block number where the batch was created */
+  blockNumber: string
+}
+
+/** Callbacks for monitoring swap/batch execution progress */
+export interface SwapCallbacks {
+  /** Called when overall flow status changes */
+  onStatusChange?: (status: 'pending' | 'in-progress' | 'completed' | 'failed') => void
+  /** Called when individual step statuses change */
+  onStepChange?: (steps: Record<string, StepStatus>) => void
+  /** Called when a step produces metadata (e.g. explorer URLs) */
+  onMetadata?: (key: string, value: string) => void
+  /** Called when a step encounters an error */
+  onError?: (error: Error) => void
+  /** Called when a batch is created (batch mode only) */
+  onBatchCreated?: (data: { batchId: string; depth: number; amount: string; blockNumber: string }) => void
+}
+
+/** Options for constructing a MultichainSDK instance */
+export interface MultichainSDKOptions {
+  /** Custom RPC URLs per chain */
+  rpcUrls?: Partial<Record<SupportedChainId | 100, string>>
+  /** Settings passed to @upcoming/multichain-library */
+  librarySettings?: Partial<MultichainLibrarySettings>
+  /** Use mocked steps (no real blockchain transactions) */
+  mocked?: boolean
+}

--- a/src/wallets/EvmPrivateKeyWallet.ts
+++ b/src/wallets/EvmPrivateKeyWallet.ts
@@ -1,0 +1,61 @@
+import { createWalletClient, http } from 'viem'
+import { privateKeyToAccount } from 'viem/accounts'
+import type { EvmWalletAdapter, SupportedChainId } from '../types'
+import { DEFAULT_RPC_URLS, SUPPORTED_CHAINS } from '../config'
+
+interface EvmPrivateKeyWalletOptions {
+  /** Hex-encoded private key (with or without 0x prefix) */
+  privateKey: `0x${string}`
+  /** Source chain ID */
+  chainId: SupportedChainId
+  /** Custom RPC URL (defaults to DEFAULT_RPC_URLS[chainId]) */
+  rpcUrl?: string
+}
+
+/**
+ * Wallet adapter backed by a raw private key.
+ *
+ * @example
+ * ```typescript
+ * const wallet = new EvmPrivateKeyWallet({
+ *   privateKey: '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80',
+ *   chainId: 8453
+ * })
+ * const result = await sdk.swap({ wallet, sourceChain: 8453, targetAddress: '0x...', bzzAmount: 10 })
+ * ```
+ */
+export class EvmPrivateKeyWallet implements EvmWalletAdapter {
+  readonly type = 'evm' as const
+  private readonly account
+  private readonly client
+
+  constructor(options: EvmPrivateKeyWalletOptions) {
+    this.account = privateKeyToAccount(options.privateKey)
+    const chain = SUPPORTED_CHAINS[options.chainId]
+    const rpcUrl = options.rpcUrl || DEFAULT_RPC_URLS[options.chainId]
+    this.client = createWalletClient({
+      account: this.account,
+      chain,
+      transport: http(rpcUrl),
+    })
+  }
+
+  async getAddress(): Promise<`0x${string}`> {
+    return this.account.address
+  }
+
+  async getChainId(): Promise<number> {
+    return this.client.chain!.id
+  }
+
+  async sendTransaction(tx: { to: `0x${string}`; value: bigint }): Promise<`0x${string}`> {
+    return this.client.sendTransaction({
+      to: tx.to,
+      value: tx.value,
+    })
+  }
+
+  async getWalletClient() {
+    return this.client
+  }
+}

--- a/src/wallets/EvmWalletClientAdapter.ts
+++ b/src/wallets/EvmWalletClientAdapter.ts
@@ -1,0 +1,48 @@
+import type { WalletClient } from 'viem'
+import type { EvmWalletAdapter } from '../types'
+
+/**
+ * Wraps any existing viem WalletClient as an EvmWalletAdapter.
+ * Use this for Coinbase AgentKit, Turnkey, Lit Protocol, or any viem-compatible wallet.
+ *
+ * @example
+ * ```typescript
+ * import { createWalletClient, http } from 'viem'
+ * import { base } from 'viem/chains'
+ *
+ * const viemClient = createWalletClient({ account, chain: base, transport: http() })
+ * const wallet = new EvmWalletClientAdapter(viemClient)
+ * const result = await sdk.swap({ wallet, sourceChain: 8453, targetAddress: '0x...', bzzAmount: 10 })
+ * ```
+ */
+export class EvmWalletClientAdapter implements EvmWalletAdapter {
+  readonly type = 'evm' as const
+  private readonly client: WalletClient
+
+  constructor(client: WalletClient) {
+    this.client = client
+  }
+
+  async getAddress(): Promise<`0x${string}`> {
+    const addresses = await this.client.getAddresses()
+    return addresses[0]
+  }
+
+  async getChainId(): Promise<number> {
+    return this.client.chain!.id
+  }
+
+  async sendTransaction(tx: { to: `0x${string}`; value: bigint }): Promise<`0x${string}`> {
+    const [account] = await this.client.getAddresses()
+    return this.client.sendTransaction({
+      account,
+      to: tx.to,
+      value: tx.value,
+      chain: this.client.chain,
+    })
+  }
+
+  async getWalletClient() {
+    return this.client
+  }
+}

--- a/src/wallets/SolanaKeypairWallet.ts
+++ b/src/wallets/SolanaKeypairWallet.ts
@@ -1,0 +1,9 @@
+/**
+ * Solana wallet adapter — Phase 4 stub.
+ * Will support Solana → Gnosis swaps via deBridge DLN.
+ */
+export class SolanaKeypairWallet {
+  constructor(_keypair: unknown) {
+    throw new Error('Solana wallet support is not yet implemented (Phase 4)')
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "bundler",
+    "lib": ["ES2020"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "isolatedModules": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "src/__tests__"]
+}

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  splitting: false,
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+})


### PR DESCRIPTION
## Summary

- Implements the full Phase 1 headless SDK for cross-chain token swaps to Gnosis chain
- Adapted from the multichain-widget React codebase, stripping all browser/React dependencies
- 40 files, 48 tests, dual CJS+ESM build, zero browser globals

## What's included

**Core (4 files):** `MultichainSDK` class with `getQuote()`, `executeSwap()`, `swap()`, `createBatch()`, `getBzzPrice()`, `getStoragePrice()`. Typed error classes (8), chain config, barrel export.

**Wallets (3 files):** `EvmPrivateKeyWallet` (raw keys), `EvmWalletClientAdapter` (viem WalletClient wrapper), `SolanaKeypairWallet` (Phase 4 stub).

**Steps (16 files):** 8 production + 8 mocked, adapted from widget with `setMetadata` → `onMetadata` and `window.parent.postMessage` → `onBatchCreated` callback.

**Flows (2 files):** Funding flow (6 steps) and batch flow (8 steps) via Solver pattern. Phase 4 Solana stub.

**Provider (2 files):** `RelayProvider` wrapping `@relayprotocol/relay-sdk` for EXACT_OUTPUT quotes.

**Tests (5 files, 48 tests):** Error classes, config utils, both wallet adapters, barrel exports, mocked SDK integration (funding + batch + edge cases).

## Closes

Closes #5, #6, #7, #8, #9, #10, #11, #12, #13, #14, #15
Resolves #2

## Test plan

- [x] `pnpm check` — zero type errors, no DOM references
- [x] `pnpm build` — CJS + ESM + declarations
- [x] `pnpm test` — 48 tests pass
- [x] CJS import: `require('./dist/index.cjs')` works
- [x] ESM import: `import from './dist/index.js'` works
- [x] `grep -r 'window|document|localStorage' dist/` — zero matches