### PR TITLE
Make getQuote() work without a wallet

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,10 @@ console.log('Batch ID:', result.batchId)
 
 ### 4. Preview costs before executing
 
+No wallet or private key needed — just specify what you want:
+
 ```typescript
 const quote = await sdk.getQuote({
-  wallet,
   sourceChain: 8453,
   targetAddress: '0xBeeNode...',
   bzzAmount: 10,
@@ -218,7 +219,7 @@ The `examples/` directory contains runnable scripts demonstrating common SDK use
 Run any example with:
 
 ```bash
-PRIVATE_KEY=0x... npx tsx examples/quote-preview.ts
+npx tsx examples/quote-preview.ts                                        # No wallet needed
 PRIVATE_KEY=0x... TARGET_ADDRESS=0x... npx tsx examples/fund-bee-node.ts
 PRIVATE_KEY=0x... TARGET_ADDRESS=0x... npx tsx examples/create-batch.ts
 PRIVATE_KEY=0x... npx tsx examples/mock-llm-agent.ts

--- a/examples/quote-preview.ts
+++ b/examples/quote-preview.ts
@@ -2,20 +2,20 @@
  * Quote Preview — Get a cross-chain swap quote without executing
  *
  * This example demonstrates how to use the SDK to preview swap costs
- * before committing any funds. Useful for agents that need to evaluate
- * whether a swap is worth executing.
+ * before committing any funds. No private key or wallet is required —
+ * just specify what you want and see the price.
  *
  * Usage:
- *   PRIVATE_KEY=0x... npx tsx examples/quote-preview.ts
+ *   npx tsx examples/quote-preview.ts
  *
  * Optional env vars:
- *   SOURCE_CHAIN  — Source chain ID (default: 8453 for Base)
+ *   SOURCE_CHAIN   — Source chain ID (default: 8453 for Base)
  *   TARGET_ADDRESS — Gnosis address to receive funds (default: demo address)
- *   BZZ_AMOUNT    — Amount of xBZZ to deliver (default: 10)
- *   NATIVE_AMOUNT — Amount of xDAI to deliver (default: 0.5)
+ *   BZZ_AMOUNT     — Amount of xBZZ to deliver (default: 10)
+ *   NATIVE_AMOUNT  — Amount of xDAI to deliver (default: 0.5)
  */
 
-import { MultichainSDK, EvmPrivateKeyWallet, type SupportedChainId } from '../src/index'
+import { MultichainSDK, type SupportedChainId } from '../src/index'
 
 const CHAIN_NAMES: Record<number, string> = {
   1: 'Ethereum',
@@ -27,13 +27,6 @@ const CHAIN_NAMES: Record<number, string> = {
 
 async function main() {
   // --- Configuration from environment ---
-  const privateKey = process.env.PRIVATE_KEY
-  if (!privateKey) {
-    console.error('Error: PRIVATE_KEY environment variable is required.')
-    console.error('Usage: PRIVATE_KEY=0x... npx tsx examples/quote-preview.ts')
-    process.exit(1)
-  }
-
   const sourceChain = (Number(process.env.SOURCE_CHAIN) || 8453) as SupportedChainId
   const targetAddress = (process.env.TARGET_ADDRESS || '0x1234567890123456789012345678901234567890') as `0x${string}`
   const bzzAmount = Number(process.env.BZZ_AMOUNT) || 10
@@ -41,26 +34,18 @@ async function main() {
 
   // --- Setup ---
   const sdk = new MultichainSDK()
-  const wallet = new EvmPrivateKeyWallet({
-    privateKey: privateKey as `0x${string}`,
-    chainId: sourceChain,
-  })
-
-  const sourceAddress = await wallet.getAddress()
 
   console.log('=== Multichain SDK — Quote Preview ===\n')
-  console.log(`Source wallet:  ${sourceAddress}`)
   console.log(`Source chain:   ${CHAIN_NAMES[sourceChain] || sourceChain} (${sourceChain})`)
   console.log(`Target address: ${targetAddress}`)
   console.log(`BZZ amount:     ${bzzAmount} xBZZ`)
   console.log(`Native amount:  ${nativeAmount} xDAI`)
   console.log('')
 
-  // --- Fetch quote ---
+  // --- Fetch quote (no wallet needed!) ---
   console.log('Fetching quote from Relay Protocol...\n')
 
   const quote = await sdk.getQuote({
-    wallet,
     sourceChain,
     targetAddress,
     bzzAmount,
@@ -78,7 +63,7 @@ async function main() {
   console.log(`Temporary address:     ${quote.temporaryAddress}`)
   console.log('')
   console.log('Quote fetched successfully. No funds were spent.')
-  console.log('To execute this swap, use sdk.executeSwap(quote, wallet)')
+  console.log('To execute this swap, call sdk.executeSwap(quote, wallet)')
 }
 
 main().catch((error) => {

--- a/src/MultichainSDK.ts
+++ b/src/MultichainSDK.ts
@@ -9,11 +9,15 @@ import type {
   BatchResult,
   EvmWalletAdapter,
   MultichainSDKOptions,
+  QuoteRequest,
   SwapCallbacks,
   SwapQuote,
   SwapRequest,
   SwapResult,
 } from './types'
+
+/** Dummy address used for Relay quotes when no wallet is provided */
+const DUMMY_SOURCE_ADDRESS = '0x0000000000000000000000000000000000000001' as `0x${string}`
 
 /**
  * Main SDK class for cross-chain swaps to Gnosis and Swarm postage batch creation.
@@ -52,18 +56,30 @@ export class MultichainSDK {
   /**
    * Get a quote for a cross-chain swap without executing it.
    *
-   * Use this to preview costs before committing funds. The quote includes
-   * the estimated source token amount, USD value, and a temporary Gnosis address.
-   * Quotes are time-sensitive — execute promptly via `executeSwap()`.
+   * No wallet or private key is required — just specify the source chain, amounts,
+   * and target address to get a price estimate. To execute the quote, pass it to
+   * `executeSwap()` with a wallet.
    *
    * For a simpler one-step flow, use `swap()` instead.
+   *
+   * @example
+   * ```typescript
+   * // Wallet-free quote (just a price check)
+   * const quote = await sdk.getQuote({
+   *   sourceChain: 8453,
+   *   targetAddress: '0xBeeNode...',
+   *   bzzAmount: 10,
+   *   nativeAmount: 0.5,
+   * })
+   * console.log(`Cost: $${quote.estimatedUsdValue.toFixed(2)}`)
+   * ```
    *
    * @throws {ConfigurationError} If the source chain is unsupported or amounts are invalid
    * @throws {PriceFetchError} If the BZZ price API is unavailable
    * @throws {NoRouteError} If Relay Protocol finds no route for the swap
    */
-  async getQuote(request: SwapRequest): Promise<SwapQuote> {
-    this.validateRequest(request)
+  async getQuote(request: QuoteRequest): Promise<SwapQuote> {
+    this.validateQuoteRequest(request)
 
     const bzzAmount = request.bzzAmount ?? 0
     const nativeAmount = request.nativeAmount ?? 0
@@ -85,7 +101,9 @@ export class MultichainSDK {
     const totalNeededUsdValue = (bzzUsdValue + nativeAmount + daiDust) * 1.1
 
     const { temporaryPrivateKey, temporaryAddress } = this.generateTemporaryWallet()
-    const sourceAddress = await request.wallet.getAddress()
+    const sourceAddress = 'wallet' in request
+      ? await (request as SwapRequest).wallet.getAddress()
+      : DUMMY_SOURCE_ADDRESS
 
     const { relayQuote, sourceTokenAmount, totalDaiValue } = await this.relayProvider.getQuote({
       sourceAddress,
@@ -182,6 +200,7 @@ export class MultichainSDK {
    * @throws {NoRouteError} If Relay Protocol finds no route for the swap
    */
   async swap(request: SwapRequest, callbacks?: SwapCallbacks): Promise<SwapResult> {
+    this.validateSwapAmounts(request)
     const quote = await this.getQuote(request)
     return this.executeSwap(quote, request.wallet, callbacks)
   }
@@ -198,7 +217,7 @@ export class MultichainSDK {
    * @throws {NoRouteError} If Relay Protocol finds no route for the swap
    */
   async createBatch(request: BatchRequest, callbacks?: SwapCallbacks): Promise<BatchResult> {
-    this.validateRequest(request)
+    this.validateChainAndAmountSigns(request)
 
     const sourceToken = request.sourceToken ?? this.library.constants.nullAddress
 
@@ -313,7 +332,7 @@ export class MultichainSDK {
     }
   }
 
-  private validateRequest(request: SwapRequest): void {
+  private validateQuoteRequest(request: QuoteRequest): void {
     if (!(request.sourceChain in SUPPORTED_CHAINS)) {
       throw new ConfigurationError(
         `Unsupported source chain: ${request.sourceChain}. Supported chains: 1 (Ethereum), 137 (Polygon), 10 (Optimism), 42161 (Arbitrum), 8453 (Base).`
@@ -330,15 +349,28 @@ export class MultichainSDK {
       throw new ConfigurationError('nativeAmount cannot be negative.')
     }
 
-    if ('batchDepth' in request) {
-      // BatchRequest — amounts are calculated from batch params, skip amount check
-      return
-    }
-
     if (bzzAmount <= 0 && nativeAmount <= 0) {
       throw new ConfigurationError(
         'At least one of bzzAmount or nativeAmount must be greater than 0.'
       )
+    }
+  }
+
+  private validateSwapAmounts(request: SwapRequest): void {
+    this.validateQuoteRequest(request)
+  }
+
+  private validateChainAndAmountSigns(request: QuoteRequest): void {
+    if (!(request.sourceChain in SUPPORTED_CHAINS)) {
+      throw new ConfigurationError(
+        `Unsupported source chain: ${request.sourceChain}. Supported chains: 1 (Ethereum), 137 (Polygon), 10 (Optimism), 42161 (Arbitrum), 8453 (Base).`
+      )
+    }
+    if ((request.bzzAmount ?? 0) < 0) {
+      throw new ConfigurationError('bzzAmount cannot be negative.')
+    }
+    if ((request.nativeAmount ?? 0) < 0) {
+      throw new ConfigurationError('nativeAmount cannot be negative.')
     }
   }
 

--- a/src/__tests__/sdk.test.ts
+++ b/src/__tests__/sdk.test.ts
@@ -297,6 +297,78 @@ describe('MultichainSDK', () => {
     }, 30000)
   })
 
+  describe('getQuote (wallet-free)', () => {
+    it('works without a wallet', async () => {
+      const sdk = new MultichainSDK()
+
+      const quote = await sdk.getQuote({
+        sourceChain: 8453,
+        targetAddress: '0x1234567890123456789012345678901234567890',
+        bzzAmount: 10,
+        nativeAmount: 0.5,
+      })
+
+      expect(quote.sourceTokenAmount).toBeDefined()
+      expect(quote.estimatedUsdValue).toBeGreaterThan(0)
+      expect(quote.bzzUsdPrice).toBeGreaterThan(0)
+      expect(quote.temporaryAddress).toMatch(/^0x[0-9a-fA-F]{40}$/)
+      expect(quote.temporaryPrivateKey).toMatch(/^0x[0-9a-f]{64}$/)
+    }, 30000)
+
+    it('works with nativeAmount only (no BZZ)', async () => {
+      const sdk = new MultichainSDK()
+
+      const quote = await sdk.getQuote({
+        sourceChain: 8453,
+        targetAddress: '0x1234567890123456789012345678901234567890',
+        nativeAmount: 1.0,
+      })
+
+      expect(quote.sourceTokenAmount).toBeDefined()
+      expect(quote.bzzUsdPrice).toBe(0)
+      expect(quote.bzzUsdValue).toBe(0)
+      expect(quote.nativeAmount).toBe(1.0)
+    }, 30000)
+
+    it('still works when a wallet is provided (backwards compatible)', async () => {
+      const sdk = new MultichainSDK()
+      const wallet = createMockWallet()
+
+      const quote = await sdk.getQuote({
+        wallet,
+        sourceChain: 8453,
+        targetAddress: '0x1234567890123456789012345678901234567890',
+        bzzAmount: 5,
+      })
+
+      expect(quote.sourceTokenAmount).toBeDefined()
+      expect(quote.estimatedUsdValue).toBeGreaterThan(0)
+    }, 30000)
+
+    it('rejects unsupported chain without wallet', async () => {
+      const sdk = new MultichainSDK()
+
+      await expect(
+        sdk.getQuote({
+          sourceChain: 999 as any,
+          targetAddress: '0x1234567890123456789012345678901234567890',
+          bzzAmount: 1,
+        }),
+      ).rejects.toThrow(ConfigurationError)
+    })
+
+    it('rejects zero amounts without wallet', async () => {
+      const sdk = new MultichainSDK()
+
+      await expect(
+        sdk.getQuote({
+          sourceChain: 8453,
+          targetAddress: '0x1234567890123456789012345678901234567890',
+        }),
+      ).rejects.toThrow(ConfigurationError)
+    })
+  })
+
   describe('getBzzPrice', () => {
     it('returns a positive number', async () => {
       const sdk = new MultichainSDK()

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export { MultichainSDK } from './MultichainSDK'
 export type {
   EvmWalletAdapter,
+  QuoteRequest,
   SwapRequest,
   BatchRequest,
   SwapQuote,

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,36 @@ export interface EvmWalletAdapter {
 }
 
 /**
+ * Request for a price quote — no wallet required.
+ *
+ * Use this with `sdk.getQuote()` to preview costs before committing funds.
+ * At least one of `bzzAmount` or `nativeAmount` must be > 0. Both must be non-negative.
+ *
+ * @example
+ * ```typescript
+ * const quote = await sdk.getQuote({
+ *   sourceChain: 8453,
+ *   targetAddress: '0xBeeNode...',
+ *   bzzAmount: 10,
+ *   nativeAmount: 0.5,
+ * })
+ * console.log(`Cost: $${quote.estimatedUsdValue.toFixed(2)}`)
+ * ```
+ */
+export interface QuoteRequest {
+  /** Source chain ID (1=Ethereum, 137=Polygon, 10=Optimism, 42161=Arbitrum, 8453=Base) */
+  sourceChain: SupportedChainId
+  /** Gnosis address to receive xBZZ and/or xDAI */
+  targetAddress: `0x${string}`
+  /** Amount of xBZZ to deliver (in whole BZZ units, e.g. 10 = 10 BZZ). Defaults to 0. Must be >= 0. */
+  bzzAmount?: number
+  /** Amount of xDAI to deliver (in whole DAI units, e.g. 0.5 = 0.5 xDAI). Defaults to 0. Must be >= 0. */
+  nativeAmount?: number
+  /** Source token address. Defaults to native token (ETH/MATIC/etc.). Most agents leave this unset. */
+  sourceToken?: `0x${string}`
+}
+
+/**
  * Request to swap tokens cross-chain and deliver xBZZ and/or xDAI to a target address on Gnosis.
  *
  * At least one of `bzzAmount` or `nativeAmount` must be > 0. Both must be non-negative.
@@ -39,19 +69,9 @@ export interface EvmWalletAdapter {
  * swaps to xBZZ via SushiSwap if needed, and transfers remaining xDAI to the target.
  * A 10% slippage buffer is included in the bridge amount.
  */
-export interface SwapRequest {
+export interface SwapRequest extends QuoteRequest {
   /** Wallet adapter providing the source funds */
   wallet: EvmWalletAdapter
-  /** Source chain ID (1=Ethereum, 137=Polygon, 10=Optimism, 42161=Arbitrum, 8453=Base) */
-  sourceChain: SupportedChainId
-  /** Gnosis address to receive xBZZ and/or xDAI */
-  targetAddress: `0x${string}`
-  /** Amount of xBZZ to deliver (in whole BZZ units, e.g. 10 = 10 BZZ). Defaults to 0. Must be >= 0. */
-  bzzAmount?: number
-  /** Amount of xDAI to deliver (in whole DAI units, e.g. 0.5 = 0.5 xDAI). Defaults to 0. Must be >= 0. */
-  nativeAmount?: number
-  /** Source token address. Defaults to native token (ETH/MATIC/etc.). Most agents leave this unset. */
-  sourceToken?: `0x${string}`
 }
 
 /**
@@ -106,8 +126,8 @@ export interface SwapQuote {
   temporaryAddress: `0x${string}`
   /** Private key for the temporary address. Save this for fund recovery if the flow fails. */
   temporaryPrivateKey: `0x${string}`
-  /** The original swap request */
-  request: SwapRequest
+  /** The original quote request parameters */
+  request: QuoteRequest
 }
 
 /**


### PR DESCRIPTION
## Summary
- `getQuote()` no longer requires a wallet or private key — just specify chain, amounts, and target address
- New `QuoteRequest` type for wallet-free quotes; `SwapRequest` extends it (backwards compatible)
- Uses a dummy source address for Relay API when no wallet is provided
- Updated `quote-preview.ts` example: no `PRIVATE_KEY` needed
- Updated README quote example
- 5 new wallet-free quote tests (total now 97)

## Before
```typescript
// Required a wallet just to check prices
const wallet = new EvmPrivateKeyWallet({ privateKey: '0x...', chainId: 8453 })
const quote = await sdk.getQuote({ wallet, sourceChain: 8453, ... })
```

## After
```typescript
// Just ask for a price — no wallet needed
const quote = await sdk.getQuote({ sourceChain: 8453, targetAddress: '0x...', bzzAmount: 10 })
```

Closes #47