### PR TITLE
Add chain and token discovery methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,18 @@ console.log(`Estimated: $${quote.estimatedUsdValue.toFixed(2)}`)
 const result = await sdk.executeSwap(quote, wallet)
 ```
 
+### 5. Discover supported chains and tokens
+
+```typescript
+// List supported source chains
+const chains = sdk.getSupportedChains()
+// [{ id: 1, name: 'Ethereum' }, { id: 8453, name: 'Base' }, ...]
+
+// List available tokens on a chain
+const tokens = await sdk.getSupportedTokens(8453)
+// [{ address: '0x...', symbol: 'ETH', name: 'Ether', decimals: 18 }, ...]
+```
+
 ## Supported Chains
 
 | Chain | ID |

--- a/src/MultichainSDK.ts
+++ b/src/MultichainSDK.ts
@@ -7,6 +7,7 @@ import { RelayProvider } from './providers/RelayProvider'
 import type {
   BatchRequest,
   BatchResult,
+  ChainInfo,
   EvmWalletAdapter,
   MultichainSDKOptions,
   QuoteRequest,
@@ -14,6 +15,7 @@ import type {
   SwapQuote,
   SwapRequest,
   SwapResult,
+  TokenInfo,
 } from './types'
 
 /** Dummy address used for Relay quotes when no wallet is provided */
@@ -330,6 +332,46 @@ export class MultichainSDK {
     } catch (error) {
       throw new PriceFetchError('storage price', error instanceof Error ? error : undefined)
     }
+  }
+
+  /**
+   * Get the list of supported source chains.
+   *
+   * @example
+   * ```typescript
+   * const chains = sdk.getSupportedChains()
+   * // [{ id: 1, name: 'Ethereum' }, { id: 137, name: 'Polygon' }, ...]
+   * ```
+   */
+  getSupportedChains(): ChainInfo[] {
+    return Object.entries(SUPPORTED_CHAINS).map(([id, chain]) => ({
+      id: Number(id) as ChainInfo['id'],
+      name: chain.name,
+    }))
+  }
+
+  /**
+   * Get the list of tokens available for swapping on a given source chain.
+   *
+   * Queries the Relay Protocol API for verified tokens. Results include the
+   * native token and popular ERC-20s (USDC, USDT, WETH, etc.).
+   *
+   * @param chainId - Source chain ID (e.g. 8453 for Base)
+   * @throws {ConfigurationError} If the chain ID is not supported
+   *
+   * @example
+   * ```typescript
+   * const tokens = await sdk.getSupportedTokens(8453)
+   * // [{ address: '0x000...', symbol: 'ETH', name: 'Ether', decimals: 18 }, ...]
+   * ```
+   */
+  async getSupportedTokens(chainId: number): Promise<TokenInfo[]> {
+    if (!(chainId in SUPPORTED_CHAINS)) {
+      throw new ConfigurationError(
+        `Unsupported chain: ${chainId}. Supported chains: ${this.getSupportedChains().map(c => `${c.id} (${c.name})`).join(', ')}.`
+      )
+    }
+    return this.relayProvider.getTokens(chainId)
   }
 
   private validateQuoteRequest(request: QuoteRequest): void {

--- a/src/__tests__/sdk.test.ts
+++ b/src/__tests__/sdk.test.ts
@@ -536,6 +536,60 @@ describe('MultichainSDK', () => {
     }, 30000)
   })
 
+  describe('getSupportedChains', () => {
+    it('returns all 5 supported chains', () => {
+      const sdk = new MultichainSDK()
+      const chains = sdk.getSupportedChains()
+      expect(chains).toHaveLength(5)
+    })
+
+    it('includes expected chain IDs', () => {
+      const sdk = new MultichainSDK()
+      const chains = sdk.getSupportedChains()
+      const ids = chains.map(c => c.id)
+      expect(ids).toContain(1)
+      expect(ids).toContain(137)
+      expect(ids).toContain(10)
+      expect(ids).toContain(42161)
+      expect(ids).toContain(8453)
+    })
+
+    it('returns id and name for each chain', () => {
+      const sdk = new MultichainSDK()
+      const chains = sdk.getSupportedChains()
+      for (const chain of chains) {
+        expect(typeof chain.id).toBe('number')
+        expect(typeof chain.name).toBe('string')
+        expect(chain.name.length).toBeGreaterThan(0)
+      }
+    })
+  })
+
+  describe('getSupportedTokens', () => {
+    it('returns tokens for Base', async () => {
+      const sdk = new MultichainSDK()
+      const tokens = await sdk.getSupportedTokens(8453)
+      expect(tokens.length).toBeGreaterThan(0)
+      for (const token of tokens) {
+        expect(typeof token.address).toBe('string')
+        expect(typeof token.symbol).toBe('string')
+        expect(typeof token.name).toBe('string')
+        expect(typeof token.decimals).toBe('number')
+      }
+    }, 30000)
+
+    it('returns tokens for Ethereum', async () => {
+      const sdk = new MultichainSDK()
+      const tokens = await sdk.getSupportedTokens(1)
+      expect(tokens.length).toBeGreaterThan(0)
+    }, 30000)
+
+    it('rejects unsupported chain ID', async () => {
+      const sdk = new MultichainSDK()
+      await expect(sdk.getSupportedTokens(999)).rejects.toThrow(ConfigurationError)
+    })
+  })
+
   describe('concurrent calls', () => {
     it('concurrent swaps generate unique temporary wallets', async () => {
       const sdk = new MultichainSDK({ mocked: true })

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,8 @@ export type {
   MultichainSDKOptions,
   SupportedChainId,
   StepStatus,
+  ChainInfo,
+  TokenInfo,
 } from './types'
 export { EvmPrivateKeyWallet } from './wallets/EvmPrivateKeyWallet'
 export { EvmWalletClientAdapter } from './wallets/EvmWalletClientAdapter'

--- a/src/providers/RelayProvider.ts
+++ b/src/providers/RelayProvider.ts
@@ -3,6 +3,7 @@ import { MultichainLibrary, xDAI } from '@upcoming/multichain-library'
 import { FixedPointNumber, Objects } from 'cafe-utility'
 import { getRelayChains } from '../config'
 import { NoRouteError } from '../errors'
+import type { TokenInfo } from '../types'
 
 interface QuoteParams {
   sourceAddress: `0x${string}`
@@ -28,6 +29,29 @@ export class RelayProvider {
 
   getClient(): RelayClient {
     return this.client
+  }
+
+  async getTokens(chainId: number): Promise<TokenInfo[]> {
+    const response = await fetch('https://api.relay.link/currencies/v2', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ chainIds: [chainId], verified: true, limit: 100 }),
+    })
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch tokens for chain ${chainId}: ${response.status} ${response.statusText}`)
+    }
+
+    const currencies = await response.json() as Array<{ address?: string; symbol?: string; name?: string; decimals?: number }>
+
+    return currencies
+      .filter((c): c is { address: string; symbol: string; name: string; decimals: number } =>
+        typeof c.address === 'string' &&
+        typeof c.symbol === 'string' &&
+        typeof c.name === 'string' &&
+        typeof c.decimals === 'number'
+      )
+      .map(c => ({ address: c.address, symbol: c.symbol, name: c.name, decimals: c.decimals }))
   }
 
   async getQuote(params: QuoteParams): Promise<QuoteResult> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,26 @@ export type SupportedChainId = 1 | 137 | 10 | 42161 | 8453
 /** Status of an individual step in a flow */
 export type StepStatus = 'pending' | 'in-progress' | 'completed' | 'failed' | 'skipped'
 
+/** Summary info for a supported source chain */
+export interface ChainInfo {
+  /** Chain ID (e.g. 8453 for Base) */
+  id: SupportedChainId
+  /** Human-readable chain name (e.g. 'Base') */
+  name: string
+}
+
+/** Summary info for a token available on a source chain */
+export interface TokenInfo {
+  /** Token contract address (null address for native token) */
+  address: string
+  /** Token ticker symbol (e.g. 'ETH', 'USDC') */
+  symbol: string
+  /** Full token name (e.g. 'Ether', 'USD Coin') */
+  name: string
+  /** Token decimals (e.g. 18 for ETH, 6 for USDC) */
+  decimals: number
+}
+
 /**
  * Minimal wallet interface that any EVM wallet provider can implement.
  *


### PR DESCRIPTION
## Summary

- **`getSupportedChains()`** — returns `ChainInfo[]` with `{ id, name }` for all 5 supported source chains
- **`getSupportedTokens(chainId)`** — queries Relay Protocol `/currencies/v2` API for verified tokens on a given chain, returns `TokenInfo[]` with `{ address, symbol, name, decimals }`
- New `ChainInfo` and `TokenInfo` types exported from barrel

Closes #49, closes #50

## Test plan

- [x] `getSupportedChains()` returns all 5 chains with correct structure
- [x] `getSupportedTokens(8453)` returns tokens for Base
- [x] `getSupportedTokens(1)` returns tokens for Ethereum
- [x] `getSupportedTokens(999)` throws `ConfigurationError`
- [x] All 103 tests pass